### PR TITLE
Fix setup.sh to preserve git-tracked configs and fix missing mods

### DIFF
--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -464,6 +464,11 @@ hash = "426fd37ec95797af16797632e70c63436ca12719c0adb16ffca931970a411ee2"
 metafile = true
 
 [[files]]
+file = "mods/mmmmmmmmmmmm.pw.toml"
+hash = "cb6a545e5739fc0e5df919fd60d729cb20634c9febd29b133eca4f172d90aa97"
+metafile = true
+
+[[files]]
 file = "mods/mob-grinding-utils.pw.toml"
 hash = "22ffca942573f1c39cc6c495122a31706a12eeb655c013c6c017aa1306ccaf7b"
 metafile = true
@@ -471,6 +476,11 @@ metafile = true
 [[files]]
 file = "mods/modular-routers.pw.toml"
 hash = "38eff2e2ce05f4d0a2f0bd8b53e0c71b39900ed530dcda25df28b2a84bbb217d"
+metafile = true
+
+[[files]]
+file = "mods/moonlight.pw.toml"
+hash = "43ab3490d87a5b72af0c1fc676e625985d68e7e453338acc7fd2558fb6a4bf6b"
 metafile = true
 
 [[files]]
@@ -580,7 +590,7 @@ metafile = true
 
 [[files]]
 file = "mods/rftools-dimensions.pw.toml"
-hash = "53a70b48e6400e7ac1ae3d24176d967859d4b382dfbbbc95bb6995992ae43a10"
+hash = "cfe0ab30f0b7a4e145d068855158bdc495d8428b1582ef473338b5389593f66b"
 metafile = true
 
 [[files]]

--- a/cwagecraft/mods/mmmmmmmmmmmm.pw.toml
+++ b/cwagecraft/mods/mmmmmmmmmmmm.pw.toml
@@ -1,0 +1,13 @@
+name = "MmmMmmMmmMmm"
+filename = "dummmmmmy-1.20-2.0.9.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/Adega8YN/versions/zAahRq2q/dummmmmmy-1.20-2.0.9.jar"
+hash-format = "sha512"
+hash = "43d86873c4463f483daaacba7c3d4df419c95c78327ad248ae0c18ff3439a6d07f0f6386421b043b231b4e57f52699ae56d95a7346ac174f98726ef690c5c48b"
+
+[update]
+[update.modrinth]
+mod-id = "Adega8YN"
+version = "zAahRq2q"

--- a/cwagecraft/mods/moonlight.pw.toml
+++ b/cwagecraft/mods/moonlight.pw.toml
@@ -1,0 +1,13 @@
+name = "Moonlight Lib"
+filename = "moonlight-1.20-2.16.6-forge.jar"
+side = "both"
+
+[download]
+url = "https://cdn.modrinth.com/data/twkfQtEc/versions/73JYIfG3/moonlight-1.20-2.16.6-forge.jar"
+hash-format = "sha512"
+hash = "2e88f176183d15c566b49d0c89b59c61a98a20f360c94a290142b7116b5fef557f4c7b5b5657e05595a08e6b2ef8ed91ae7671f2ca14cc43a05e900cbe7938d8"
+
+[update]
+[update.modrinth]
+mod-id = "twkfQtEc"
+version = "73JYIfG3"

--- a/cwagecraft/mods/rftools-dimensions.pw.toml
+++ b/cwagecraft/mods/rftools-dimensions.pw.toml
@@ -3,11 +3,11 @@ filename = "rftoolsdim-1.20-11.0.10.jar"
 side = "both"
 
 [download]
-hash-format = "sha1"
-hash = "4b8425c03778054801f0268f34b4a7a9b6d57392"
-mode = "metadata:curseforge"
+url = "https://cdn.modrinth.com/data/N4D9AicU/versions/SxzunA0z/rftoolsdim-1.20-11.0.10.jar"
+hash-format = "sha512"
+hash = "b037c027322aa96194cfc07d34ca3961d8f2601590cece2a32395ce3e031c97be6f1bdf21230322cacacc8ade75baae6b84f99f0d3a3dbe901e99b9e5361fca5"
 
 [update]
-[update.curseforge]
-file-id = 5884304
-project-id = 240950
+[update.modrinth]
+mod-id = "N4D9AicU"
+version = "SxzunA0z"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "7db867805f7d327060491ddef750641b892d298fb8a028c7acf6f69ddde53457"
+hash = "7268ea9ba4b7086cf05a9c074941e4faf5434961c84423def428b9f13e9452cf"
 
 [versions]
 forge = "47.3.22"

--- a/setup.sh
+++ b/setup.sh
@@ -11,39 +11,43 @@ MRPACK="$OUT_DIR/${PACK_NAME}.mrpack"
 PW="packwiz -y"
 
 echo "==> Reset"
-rm -rf "$PACK_DIR" "$MRPACK"
+rm -rf "$MRPACK"
 mkdir -p "$PACK_DIR"
 cd "$PACK_DIR"
 
-echo "==> Init pack ($MC_VERSION Forge $FORGE_VERSION)"
-# Retry packwiz init on network failures (TLS handshake timeouts, etc.)
-init_success=false
-for attempt in 1 2; do
-    if [[ $attempt -gt 1 ]]; then
-        echo "    Init attempt $attempt/2 (network error, retrying...)"
-        sleep 2
-    fi
-    
-    if $PW init \
-      --name "$PACK_NAME" \
-      --author "$AUTHOR" \
-      --version "1.0.0" \
-      --mc-version "$MC_VERSION" \
-      --modloader forge \
-      --forge-version "$FORGE_VERSION"; then
-        init_success=true
-        break
-    fi
-done
+if [[ ! -f "$PACK_DIR/pack.toml" ]]; then
+    echo "==> Init pack ($MC_VERSION Forge $FORGE_VERSION)"
+    # Retry packwiz init on network failures (TLS handshake timeouts, etc.)
+    init_success=false
+    for attempt in 1 2; do
+        if [[ $attempt -gt 1 ]]; then
+            echo "    Init attempt $attempt/2 (network error, retrying...)"
+            sleep 2
+        fi
+        
+        if $PW init \
+          --name "$PACK_NAME" \
+          --author "$AUTHOR" \
+          --version "1.0.0" \
+          --mc-version "$MC_VERSION" \
+          --modloader forge \
+          --forge-version "$FORGE_VERSION"; then
+            init_success=true
+            break
+        fi
+    done
 
-if [[ "$init_success" != "true" ]]; then
-    echo "ERROR: Failed to initialize pack after 2 attempts"
-    exit 1
+    if [[ "$init_success" != "true" ]]; then
+        echo "ERROR: Failed to initialize pack after 2 attempts"
+        exit 1
+    fi
+
+    echo "==> Accept MC $MC_VERSION family"
+    $PW settings acceptable-versions --add 1.20
+    $PW settings acceptable-versions --add 1.20.1
+else
+    echo "==> Pack already exists, skipping init"
 fi
-
-echo "==> Accept MC $MC_VERSION family"
-$PW settings acceptable-versions --add 1.20
-$PW settings acceptable-versions --add 1.20.1
 
 # Helper function - prefer Modrinth with CurseForge fallback with retry logic
 # Usage: add_mod "display-name" "slug" "modrinth-id" ["curseforge-id"]
@@ -222,7 +226,7 @@ echo "==> Quality of life additions"
 add_mod "Default Options" "default-options" "IWe7P9UP" "232131"            # Ship default options and keybindings
 add_mod "OpenLoader" "open-loader" "dWV6rGSH" "226447"                      # Automatic datapack/resource pack loading
 add_mod "Paragliders" "paragliders" "esqWA0aQ" "328301"                     # Hang gliders for exploration
-add_mod "mmmmmmmmmmmm" "mmmmmmmmmmmm" "fEhFRm5O" ""                        # Target dummy for combat testing
+add_mod "mmmmmmmmmmmm" "mmmmmmmmmmmm" "mmmmmmmmmmmm" ""                   # Target dummy for combat testing
 add_mod "Clean Swing Through Grass" "clean-swing-through-grass" "" "386549" # Attack through plants
 add_mod "Cobble For Days" "cobblefordays" "hi71AUZ0" "351748"              # Tiered cobblestone generators
 add_mod "Compact Machines" "compact-machines" "" "224218"                  # Pocket dimension rooms
@@ -291,52 +295,7 @@ add_mod "Embeddium" "embeddium" "embeddium" "908741"                            
 echo "==> Refresh index"
 $PW refresh
 
-echo "==> Copy pack assets"
-PACK_ASSETS_DIR="$OUT_DIR/pack-assets"
-if [[ -d "$PACK_ASSETS_DIR" ]]; then
-    echo "    Copying OpenLoader datapacks..."
-    if [[ -d "$PACK_ASSETS_DIR/config/openloader" ]]; then
-        mkdir -p "$PACK_DIR/config"
-        if [[ -d "$PACK_DIR/config/openloader" ]]; then
-            echo "    Warning: Existing OpenLoader config found in $PACK_DIR/config/openloader. Backing up to openloader.bak."
-            rm -rf "$PACK_DIR/config/openloader.bak"
-            mv "$PACK_DIR/config/openloader" "$PACK_DIR/config/openloader.bak"
-        fi
-        cp -r "$PACK_ASSETS_DIR/config/openloader" "$PACK_DIR/config/"
-    fi
-    
-    echo "    Copying datapacks..."
-    if [[ -d "$PACK_ASSETS_DIR/datapacks" ]]; then
-        cp -r "$PACK_ASSETS_DIR/datapacks" "$PACK_DIR/"
-    fi
-    
-    echo "    Copying config files (excluding openloader)..."
-    if [[ -d "$PACK_ASSETS_DIR/config" ]]; then
-        # Use rsync to exclude openloader directory to avoid double-copying
-        rsync -a --exclude='openloader' "$PACK_ASSETS_DIR/config/" "$PACK_DIR/config/" 2>/dev/null || {
-            # Fallback to manual copy if rsync is not available
-            echo "    rsync not available, using manual copy with exclusions..."
-            find "$PACK_ASSETS_DIR/config" -mindepth 1 -maxdepth 1 ! -name 'openloader' -exec cp -r {} "$PACK_DIR/config/" \;
-        }
-    fi
-    
-    echo "    Copying scripts..."
-    if [[ -d "$PACK_ASSETS_DIR/scripts" ]]; then
-        cp -r "$PACK_ASSETS_DIR/scripts" "$PACK_DIR/"
-    fi
-    
-    echo "    Copying resource packs..."
-    if [[ -d "$PACK_ASSETS_DIR/resourcepacks" ]]; then
-        cp -r "$PACK_ASSETS_DIR/resourcepacks" "$PACK_DIR/"
-    fi
-    
-    echo "    Copying shader packs..."
-    if [[ -d "$PACK_ASSETS_DIR/shaderpacks" ]]; then
-        cp -r "$PACK_ASSETS_DIR/shaderpacks" "$PACK_DIR/"
-    fi
-else
-    echo "    No pack-assets directory found, skipping custom assets"
-fi
+echo "==> Configs and assets already in git, skipping pack-assets copy"
 
 echo "==> Export Modrinth pack (.mrpack)"
 $PW modrinth export --output "$MRPACK" --restrictDomains=false


### PR DESCRIPTION
## Summary

- Fixed setup.sh deleting git-tracked configs and custom datapacks
- Fixed missing mmmmmmmmmmmm target dummy mod  
- Setup script now preserves existing configs while properly managing mods

## Issues Fixed

### Config Deletion Problem
The setup.sh was incorrectly deleting the entire `cwagecraft/` directory and overwriting tracked configs:

- **Removed** `rm -rf "$PACK_DIR"` that deleted the entire cwagecraft directory
- **Skip packwiz init** when pack.toml already exists to avoid overwriting  
- **Removed pack-assets copying** that overwrote tracked configs with pack-assets

### Missing mmmmmmmmmmmm Mod
The target dummy mod was silently failing to install:

- **Fixed Modrinth ID** from invalid `fEhFRm5O` to working `mmmmmmmmmmmm`
- **Added missing Moonlight Lib dependency** that was required

## Test plan

- [x] Verify setup.sh no longer shows deleted config files in `git status`
- [x] Verify custom slime island datapacks are preserved  
- [x] Verify mmmmmmmmmmmm mod is included in final pack
- [x] Verify pack builds successfully with `.mrpack` export