### PR TITLE
Add glowstone to FTB Ultimine whitelist

### DIFF
--- a/cwagecraft/config/openloader/data/ftb_ultimine_ores_only/data/ftbultimine/tags/blocks/block_whitelist.json
+++ b/cwagecraft/config/openloader/data/ftb_ultimine_ores_only/data/ftbultimine/tags/blocks/block_whitelist.json
@@ -23,6 +23,7 @@
         "bigreactors:deepslate_yellorite_ore",
         "minecraft:nether_gold_ore",
         "minecraft:nether_quartz_ore",
-        "minecraft:ancient_debris"
+        "minecraft:ancient_debris",
+        "minecraft:glowstone"
     ]
 }

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -78,7 +78,7 @@ hash = "d6236766bd54d110368f5cef57ef2f1dd6e18ce8fa04d6c444caf07bddbafc1e"
 
 [[files]]
 file = "config/openloader/data/ftb_ultimine_ores_only/data/ftbultimine/tags/blocks/block_whitelist.json"
-hash = "f2324c3bd1f267308b37f850b85680a3b279bc93834ce2c95d64ab6c2ba619a4"
+hash = "a550c0711cd1cb728d4deeb3de4ffb2083f38ebc0f427431e87f6a0d94115371"
 
 [[files]]
 file = "config/openloader/data/ftb_ultimine_ores_only/data/ftbultimine/tags/blocks/excluded_blocks.json"
@@ -440,7 +440,7 @@ metafile = true
 
 [[files]]
 file = "mods/guideme.pw.toml"
-hash = "1635aa0e0df9d27f22de030955c8690061970abe26e3e913c4d950227aba4916"
+hash = "4fae5700ea63683044764c374f8651bb60c29e8bea465417d61998421724de5c"
 metafile = true
 
 [[files]]

--- a/cwagecraft/mods/guideme.pw.toml
+++ b/cwagecraft/mods/guideme.pw.toml
@@ -1,13 +1,13 @@
 name = "GuideME"
-filename = "guideme-20.1.11.jar"
+filename = "guideme-20.1.12.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/Ck4E7v7R/versions/mfDRKud3/guideme-20.1.11.jar"
+url = "https://cdn.modrinth.com/data/Ck4E7v7R/versions/EaVlVvP1/guideme-20.1.12.jar"
 hash-format = "sha512"
-hash = "614c00ebaa8ce6430f3bcd91ad3256cd9443af9c7ca7dc9784a901ab110b71c7e31375e51836f3551445dd42d1494160b0c57b03170cd9f964bf10255c8307b5"
+hash = "508acd73e48a12f8372e66f06bc2e029f1b02be68468c5ec2d22574fc39a3712428c2daa43d34cc2dc60276e728c421bd53295359be399197a809d218b678ab5"
 
 [update]
 [update.modrinth]
 mod-id = "Ck4E7v7R"
-version = "mfDRKud3"
+version = "EaVlVvP1"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f077363fb4df499e1d467a61a0c8bac921ca2ef00e450db29f6b366e761bd0ea"
+hash = "9672283f4c2e2c2035938d13ceef5ad8132db378a96cdba945f8f35d70e38e59"
 
 [versions]
 forge = "47.3.22"


### PR DESCRIPTION
## Summary
- Add glowstone to FTB Ultimine vein mining whitelist for more efficient Nether harvesting

## Changes
- Updated `cwagecraft/config/openloader/data/ftb_ultimine_ores_only/data/ftbultimine/tags/blocks/block_whitelist.json` to include `minecraft:glowstone`

## Test plan
- [ ] Load world and verify glowstone can be vein mined with FTB Ultimine
- [ ] Confirm no conflicts with existing ultimine functionality