### PR TITLE
disable hoe requirement

### DIFF
--- a/cwagecraft/defaultconfigs/pylons-server.toml
+++ b/cwagecraft/defaultconfigs/pylons-server.toml
@@ -1,0 +1,8 @@
+# Pylons server configuration for new worlds
+# Enables RF/FE power requirement for harvester pylons
+
+[harvester_pylon]
+harvesterRequiresPower = true     # use FE instead of a hoe
+harvesterPowerCost = 5            # FE per block (tune to taste)
+harvesterPowerBuffer = 1000       # default is fine (must be > cost * 80)
+harvesterRequiresTool = false     # optional; power mode ignores tools anyway

--- a/cwagecraft/defaultconfigs/pylons-server.toml
+++ b/cwagecraft/defaultconfigs/pylons-server.toml
@@ -5,4 +5,3 @@
 harvesterRequiresPower = true     # use FE instead of a hoe
 harvesterPowerCost = 5            # FE per block (tune to taste)
 harvesterPowerBuffer = 1000       # default is fine (must be > cost * 80)
-harvesterRequiresTool = false     # optional; power mode ignores tools anyway

--- a/cwagecraft/defaultconfigs/pylons-server.toml
+++ b/cwagecraft/defaultconfigs/pylons-server.toml
@@ -1,7 +1,5 @@
 # Pylons server configuration for new worlds
-# Enables RF/FE power requirement for harvester pylons
+# Disables tool requirement for harvester pylons
 
 [harvester_pylon]
-harvesterRequiresPower = true     # use FE instead of a hoe
-harvesterPowerCost = 5            # FE per block (tune to taste)
-harvesterPowerBuffer = 1000       # default is fine (must be > cost * 80)
+harvesterRequiresTool = false

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -177,8 +177,12 @@ file = "defaultconfigs/ftb-ultimine-forge.toml"
 hash = "a4d1f7501d81af76a804d181e80ac854fa904cf4484d7f108e67b5bfb50ca16b"
 
 [[files]]
+file = "defaultconfigs/pylons-server.toml"
+hash = "41283e5a5c8c99599502ff45aed4a8b31b2673f8fef92b7b0e26ad62d2e34271"
+
+[[files]]
 file = "kubejs/client_scripts/jei_fusion_unhide.js"
-hash = "730d6e3daa6670112ea0f473565e223eb6d460579869ad6ebabc3ff629a82f1d"
+hash = "a9794c0a78d62d3f628052aef13ca1b609dd64e28de7173c321472cccbfc9b0a"
 
 [[files]]
 file = "mods/advanced-mining-dimension.pw.toml"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "f0983beceba543887648cda449a43c4543700ac0efdca87114c56911cb23ac37"
+hash = "0bbccd9c115145e8c753d6d69bfb60638c5414fd40bea7fab85fe5d9d8b15b45"
 
 [versions]
 forge = "47.3.22"


### PR DESCRIPTION
disables tool requirement for harvester pylons (originally intended to use RF power but it's not working yet)