### PR TITLE
Refactor: mods.yaml source of truth + pinned-by-default; add --upgrade/--export-mods

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,9 +9,11 @@ This is a Minecraft modpack repository using Packwiz for mod management. The mod
 ## Commands
 
 ### Primary Command (SOURCE OF TRUTH)
-- **Setup/Reset Pack**: `./setup.sh` - Completely rebuilds the modpack from scratch
+- **Setup/Reset Pack**: `./setup.sh` - Builds the modpack from `mods.yaml`
   - This is the **ONLY** command that should be used to modify the modpack
-  - All mod additions, removals, and changes must be made by editing setup.sh and re-running it
+  - All mod additions/removals are made by editing `mods.yaml` and re-running `./setup.sh`
+  - Default behavior keeps pinned versions (no automatic updates)
+  - Use `./setup.sh --upgrade` to update all mods to their latest compatible versions
 
 ### Packwiz Operations (INFORMATIONAL ONLY)
 - **List Mods**: `packwiz -y list` - Shows all mods in the current pack
@@ -21,8 +23,8 @@ This is a Minecraft modpack repository using Packwiz for mod management. The mod
 **CRITICAL**: Never use `packwiz add`, `packwiz remove`, or `packwiz refresh` commands directly. The setup.sh script is the single source of truth and handles all pack modifications. ONLY use packwiz commands for debugging/investigation - ALL modifications must go through setup.sh.
 
 ### Mod Management Helper Functions (from setup.sh)
-- `mr_add()` - Adds mods from Modrinth with logging
-- `cf_add()` - Adds mods from CurseForge with logging
+- Mods are defined declaratively in `mods.yaml` with `mr` (Modrinth id) and/or `cf` (CurseForge project id)
+- The setup script prefers Modrinth, with CurseForge as fallback
 
 ## Architecture
 
@@ -66,9 +68,10 @@ Each mod has a `.pw.toml` file containing:
 - **Important**: `grep` is aliased to `ripgrep` (rg) in this environment - use ripgrep syntax and arguments
 
 ## Workflow Rules
-1. **Modify pack**: Edit setup.sh → Run `./setup.sh`
-2. **Query pack**: Use `packwiz -y list` or similar informational commands
-3. **Never**: Use `packwiz add/remove` or modify .pw.toml files directly
+1. **Modify pack**: Edit `mods.yaml` → Run `./setup.sh`
+2. **Pinning**: Versions are pinned via generated `.pw.toml` files; only change on `--upgrade`
+3. **Query pack**: Use `packwiz -y list` or similar informational commands
+4. **Never**: Use `packwiz add/remove` or modify .pw.toml files directly
 
 ## Critical Success Validation
 - **ALWAYS check exit status**: The setup.sh script needs better exit status handling on failures

--- a/README.md
+++ b/README.md
@@ -24,6 +24,17 @@ This modpack includes **Complementary Unbound r5.5.1** shader pack by Complement
 2. Import into Prism Launcher, MultiMC, or similar launcher
 3. Launch and enjoy!
 
+## Development / Building
+
+- Source of truth: run `./setup.sh` to build/export the pack. Do not use `packwiz add/remove` directly.
+- Mods list lives in `mods.yaml`. By default, running `./setup.sh` will:
+  - Ensure each mod listed in `mods.yaml` is present.
+  - Keep existing, pinned versions (no automatic upgrades).
+- To upgrade all mods to latest tracked versions, run: `./setup.sh --upgrade`.
+- To bootstrap `mods.yaml` from the current pack state, run: `./setup.sh --export-mods`.
+
+Pinning behavior: versions are effectively pinned by the generated `cwagecraft/mods/*.pw.toml` files. The `--upgrade` flag will re-resolve versions and update those pins.
+
 ## Custom Configurations
 
 ### Tinkers' Construct Early Levelling

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -178,7 +178,7 @@ hash = "a4d1f7501d81af76a804d181e80ac854fa904cf4484d7f108e67b5bfb50ca16b"
 
 [[files]]
 file = "defaultconfigs/pylons-server.toml"
-hash = "41283e5a5c8c99599502ff45aed4a8b31b2673f8fef92b7b0e26ad62d2e34271"
+hash = "51d076ed014be250278963cd6d04910baaf8b08c0d14e017d6d76e3cb3d2578c"
 
 [[files]]
 file = "kubejs/client_scripts/jei_fusion_unhide.js"
@@ -221,7 +221,7 @@ metafile = true
 
 [[files]]
 file = "mods/balm.pw.toml"
-hash = "03d143a3507e525e5553cab391fd8c4d27b445164dc299501dd1f2678fbfb23f"
+hash = "94910057d9bf56c60c393a3cfe745f78c971005d74d9992462be7527c13315c2"
 metafile = true
 
 [[files]]

--- a/cwagecraft/mods/balm.pw.toml
+++ b/cwagecraft/mods/balm.pw.toml
@@ -3,11 +3,11 @@ filename = "balm-forge-1.20.1-7.3.34-all.jar"
 side = "both"
 
 [download]
-hash-format = "sha1"
-hash = "dd571104e24e58d9c022ae9e58fbcfa2120b0470"
-mode = "metadata:curseforge"
+url = "https://cdn.modrinth.com/data/MBAkmtvl/versions/2CQDRhU6/balm-forge-1.20.1-7.3.34-all.jar"
+hash-format = "sha512"
+hash = "50bebe4fc5e18e733f3d85ea094c1cb2b079446db1524139fc594080f4cb8bef7908bf3e62455080aeb5256de17ddb68fa91bfe7a550b68820cf51e146f82b7d"
 
 [update]
-[update.curseforge]
-file-id = 6841886
-project-id = 531761
+[update.modrinth]
+mod-id = "MBAkmtvl"
+version = "2CQDRhU6"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0bbccd9c115145e8c753d6d69bfb60638c5414fd40bea7fab85fe5d9d8b15b45"
+hash = "75f584b05812d60a4dd36abbe9cc9dd68b58d0679942263fd4a8b0ff3fc6c7a6"
 
 [versions]
 forge = "47.3.22"

--- a/mods.yaml
+++ b/mods.yaml
@@ -1,0 +1,553 @@
+mods:
+  - name: "Advanced Mining Dimension"
+    slug: advanced-mining-dimension
+    mr: XRETyQl3
+    cf: 
+  - name: "Applied Energistics 2"
+    slug: ae2
+    mr: XxWD5pD3
+    cf: 
+  - name: "AllTheCompressed"
+    slug: allthecompressed
+    mr: 
+    cf: 514045
+  - name: "Angel Block Renewed"
+    slug: angel-block-renewed
+    mr: 
+    cf: 659250
+  - name: "AppleSkin"
+    slug: appleskin
+    mr: EsAfCjCV
+    cf: 
+  - name: "Architectury API"
+    slug: architectury-api
+    mr: 
+    cf: 419699
+  - name: "Athena"
+    slug: athena-ctm
+    mr: b1ZV3DIJ
+    cf: 
+  - name: "Balm"
+    slug: balm
+    mr: MBAkmtvl
+    cf: 
+  - name: "Biomes O' Plenty"
+    slug: biomes-o-plenty
+    mr: HXF82T3G
+    cf: 
+  - name: "Bookshelf"
+    slug: bookshelf-lib
+    mr: uy4Cnpcm
+    cf: 
+  - name: "Bookshelf"
+    slug: bookshelf
+    mr: 
+    cf: 228525
+  - name: "Botania"
+    slug: botania
+    mr: pfjLUfGv
+    cf: 
+  - name: "Botany Pots"
+    slug: botany-pots
+    mr: U6BUTZ7K
+    cf: 
+  - name: "Botany Trees"
+    slug: botany-trees
+    mr: mvs7RoIW
+    cf: 
+  - name: "Brandon's Core"
+    slug: brandons-core
+    mr: 
+    cf: 231382
+  - name: "Chipped"
+    slug: chipped
+    mr: BAscRYKm
+    cf: 
+  - name: "Clean Swing Through Grass"
+    slug: clean-swing-through-grass
+    mr: 
+    cf: 915308
+  - name: "Cloth Config API"
+    slug: cloth-config
+    mr: 9s6osm5g
+    cf: 
+  - name: "CobbleForDays"
+    slug: cobblefordays
+    mr: hi71AUZ0
+    cf: 
+  - name: "CodeChicken Lib 1.8.+"
+    slug: codechicken-lib-1-8
+    mr: 
+    cf: 242818
+  - name: "CodeChicken Lib"
+    slug: codechicken-lib
+    mr: 2gq0ALnz
+    cf: 
+  - name: "CoFH Core"
+    slug: cofh-core
+    mr: OWSRM4vD
+    cf: 
+  - name: "Compact Machines"
+    slug: compact-machines
+    mr: 
+    cf: 224218
+  - name: "Construction Wand"
+    slug: construction-wand
+    mr: bV2crgLh
+    cf: 
+  - name: "Controlling"
+    slug: controlling
+    mr: xv94TkTM
+    cf: 
+  - name: "Cooking for Blockheads"
+    slug: cooking-for-blockheads
+    mr: vJnhuDde
+    cf: 
+  - name: "Crafting Station: JEI Edition"
+    slug: crafting-station-jei-edition
+    mr: 25IAE8wS
+    cf: 
+  - name: "Create Ore Excavation"
+    slug: create-ore-excavation
+    mr: 
+    cf: 649832
+  - name: "Create"
+    slug: create
+    mr: 
+    cf: 328085
+  - name: "Croptopia"
+    slug: croptopia
+    mr: 
+    cf: 415438
+  - name: "Cucumber Library"
+    slug: cucumber
+    mr: Rw1NrDzF
+    cf: 
+  - name: "Curios API (Forge/NeoForge)"
+    slug: curios
+    mr: 
+    cf: 309927
+  - name: "Cyclic"
+    slug: cyclic
+    mr: UcVTWyCI
+    cf: 
+  - name: "Dank Storage"
+    slug: dank-storage
+    mr: 
+    cf: 335673
+  - name: "Default Options"
+    slug: default-options
+    mr: 
+    cf: 232131
+  - name: "Draconic Additions"
+    slug: draconicadditions
+    mr: 
+    cf: 314515
+  - name: "Draconic Evolution"
+    slug: draconic-evolution
+    mr: 
+    cf: 223565
+  - name: "Easy Piglins"
+    slug: easy-piglins
+    mr: l6n94pax
+    cf: 
+  - name: "Easy Villagers"
+    slug: easy-villagers
+    mr: Kaov2qgi
+    cf: 
+  - name: "EdivadLib"
+    slug: edivadlib
+    mr: a8Jk9kpK
+    cf: 
+  - name: "ElevatorMod"
+    slug: elevatormod
+    mr: hi2dSXTu
+    cf: 
+  - name: "Embeddium"
+    slug: embeddium
+    mr: sk9rgfiA
+    cf: 
+  - name: "Ender Crop"
+    slug: ender-crop
+    mr: 
+    cf: 242269
+  - name: "Ender IO"
+    slug: enderio
+    mr: 49ZofO4f
+    cf: 
+  - name: "Ender Storage"
+    slug: ender-storage
+    mr: BbrHg80P
+    cf: 
+  - name: "End's Delight"
+    slug: ends-delight
+    mr: 
+    cf: 662675
+  - name: "EpheroLib"
+    slug: epherolib
+    mr: 
+    cf: 885449
+  - name: "Explorer's Compass"
+    slug: explorers-compass
+    mr: RV1qfVQ8
+    cf: 
+  - name: "ExtraStorage"
+    slug: extrastorage
+    mr: T34cBZKl
+    cf: 
+  - name: "Extreme Reactors"
+    slug: extreme-reactors
+    mr: 
+    cf: 250277
+  - name: "Farmer's Delight"
+    slug: farmers-delight
+    mr: 
+    cf: 398521
+  - name: "Fast Leaf Decay"
+    slug: fast-leaf-decay
+    mr: 
+    cf: 230976
+  - name: "FindMe"
+    slug: findme
+    mr: rEuzehyH
+    cf: 
+  - name: "Flat Bedrock (Forge / Fabric)"
+    slug: flat-bedrock
+    mr: 
+    cf: 398623
+  - name: "FLIB"
+    slug: flib
+    mr: FAUSd09K
+    cf: 
+  - name: "Flux Networks"
+    slug: flux-networks
+    mr: 
+    cf: 248020
+  - name: "Forestry: Community Edition"
+    slug: forestry-community-edition
+    mr: 2oORTOi2
+    cf: 
+  - name: "FTB Backups 2"
+    slug: ftb-backups-2
+    mr: 
+    cf: 622737
+  - name: "FTB Chunks (Forge)"
+    slug: ftb-chunks-forge
+    mr: 
+    cf: 314906
+  - name: "FTB Essentials (Forge & Fabric)"
+    slug: ftb-essentials
+    mr: 
+    cf: 410811
+  - name: "FTB Library (Forge)"
+    slug: ftb-library-forge
+    mr: 
+    cf: 404465
+  - name: "FTB Teams (Forge)"
+    slug: ftb-teams-forge
+    mr: 
+    cf: 404468
+  - name: "FTB Ultimine (Forge)"
+    slug: ftb-ultimine-forge
+    mr: 
+    cf: 386134
+  - name: "Gendustry: Community Edition"
+    slug: gendustry-community-edition
+    mr: 2zkSGMyK
+    cf: 
+  - name: "GlitchCore"
+    slug: glitchcore
+    mr: s3dmwKy5
+    cf: 
+  - name: "GraveStone Mod"
+    slug: gravestone-mod
+    mr: RYtXKJPr
+    cf: 
+  - name: "GuideME"
+    slug: guideme
+    mr: Ck4E7v7R
+    cf: 
+  - name: "Hostile Neural Networks"
+    slug: hostile-neural-networks
+    mr: 
+    cf: 552574
+  - name: "Immersive Engineering"
+    slug: immersiveengineering
+    mr: tIm2nV03
+    cf: 
+  - name: "Industrial Foregoing"
+    slug: industrial-foregoing
+    mr: lWxpUd04
+    cf: 
+  - name: "Inventory Sorter"
+    slug: inventory-sorter
+    mr: 
+    cf: 240633
+  - name: "Iron Chests"
+    slug: iron-chests
+    mr: P3iIrPH3
+    cf: 
+  - name: "Iron Jetpacks"
+    slug: iron-jetpacks
+    mr: DWIEOniQ
+    cf: 
+  - name: "Item Collectors"
+    slug: item-collectors
+    mr: y9vDr4Th
+    cf: 
+  - name: "Jade 🔍"
+    slug: jade
+    mr: nvQzSEkH
+    cf: 
+  - name: "Just Enough Items"
+    slug: jei
+    mr: u6dRKJwZ
+    cf: 
+  - name: "JourneyMap"
+    slug: journeymap
+    mr: lfHFW1mp
+    cf: 
+  - name: "Just Enough Resources (JER)"
+    slug: just-enough-resources-jer
+    mr: uEfK2CXF
+    cf: 
+  - name: "Just Enough Resources Profiler (JEARGH)"
+    slug: just-enough-resources-profiler-jeargh
+    mr: 
+    cf: 919773
+  - name: "KubeJS"
+    slug: kubejs
+    mr: 
+    cf: 238086
+  - name: "Light Overlay"
+    slug: light-overlay
+    mr: YfOlc91N
+    cf: 
+  - name: "Mantle"
+    slug: mantle
+    mr: Cg6Uc79H
+    cf: 
+  - name: "Markdown Manual"
+    slug: markdownmanual
+    mr: nPQ9xkPg
+    cf: 
+  - name: "McJtyLib"
+    slug: mcjtylib
+    mr: 1Zu0uTEE
+    cf: 
+  - name: "Mekanism Generators"
+    slug: mekanism-generators
+    mr: OFVYKsAk
+    cf: 
+  - name: "Mekanism"
+    slug: mekanism
+    mr: Ce6I4WUE
+    cf: 
+  - name: "MmmMmmMmmMmm"
+    slug: mmmmmmmmmmmm
+    mr: Adega8YN
+    cf: 
+  - name: "Mob Grinding Utils"
+    slug: mob-grinding-utils
+    mr: 
+    cf: 254241
+  - name: "Modular Routers"
+    slug: modular-routers
+    mr: EuTS81Z3
+    cf: 
+  - name: "Moonlight Lib"
+    slug: moonlight
+    mr: twkfQtEc
+    cf: 
+  - name: "Mouse Tweaks"
+    slug: mouse-tweaks
+    mr: aC3cM3Vq
+    cf: 
+  - name: "Mystical Agradditions"
+    slug: mystical-agradditions
+    mr: pl0jGXIx
+    cf: 
+  - name: "Mystical Agriculture"
+    slug: mystical-agriculture
+    mr: C95ReXie
+    cf: 
+  - name: "Nature's Compass"
+    slug: natures-compass
+    mr: fPetb5Kh
+    cf: 
+  - name: "Nether's Delight"
+    slug: nethers-delight
+    mr: 
+    cf: 496394
+  - name: "OpenComputers 2: Reimagined"
+    slug: oc2r
+    mr: F1gm4RsH
+    cf: 
+  - name: "Oculus"
+    slug: oculus
+    mr: GchcoXML
+    cf: 
+  - name: "Open Loader"
+    slug: open-loader
+    mr: 
+    cf: 354339
+  - name: "Paragliders"
+    slug: paragliders
+    mr: esqWA0aQ
+    cf: 
+  - name: "Patchouli"
+    slug: patchouli
+    mr: nU0bVIaL
+    cf: 
+  - name: "Pipez"
+    slug: pipez
+    mr: iRmWy6ga
+    cf: 
+  - name: "Placebo"
+    slug: placebo
+    mr: 
+    cf: 283644
+  - name: "PolyLib"
+    slug: polylib
+    mr: 
+    cf: 576589
+  - name: "Powah!"
+    slug: powah
+    mr: KZO4S4DO
+    cf: 
+  - name: "Pylons"
+    slug: pylons
+    mr: A82glthi
+    cf: 
+  - name: "Reap Mod"
+    slug: reap-mod
+    mr: NYHbcKK1
+    cf: 
+  - name: "Refined Storage"
+    slug: refined-storage
+    mr: KDvYkUg3
+    cf: 
+  - name: "Resourceful Lib"
+    slug: resourceful-lib
+    mr: G1hIVOrD
+    cf: 
+  - name: "RFTools Base"
+    slug: rftools-base
+    mr: hIO8IsD8
+    cf: 
+  - name: "RFTools Builder"
+    slug: rftools-builder
+    mr: e0IclJLr
+    cf: 
+  - name: "RFTools Control"
+    slug: rftools-control
+    mr: DQjhR62z
+    cf: 
+  - name: "RFTools Dimensions"
+    slug: rftools-dimensions
+    mr: N4D9AicU
+    cf: 
+  - name: "RFTools Power"
+    slug: rftools-power
+    mr: YWbLuPa1
+    cf: 
+  - name: "RFTools Storage"
+    slug: rftools-storage
+    mr: 
+    cf: 350006
+  - name: "RFTools Utility"
+    slug: rftools-utility
+    mr: 7n3HbHSE
+    cf: 
+  - name: "Rhino"
+    slug: rhino
+    mr: 
+    cf: 416294
+  - name: "Searchables"
+    slug: searchables
+    mr: fuuu3xnx
+    cf: 
+  - name: "Snad"
+    slug: snad
+    mr: 
+    cf: 241344
+  - name: "Sophisticated Backpacks"
+    slug: sophisticated-backpacks
+    mr: TyCTlI4b
+    cf: 
+  - name: "Sophisticated Core"
+    slug: sophisticated-core
+    mr: nmoqTijg
+    cf: 
+  - name: "Spice of Life: Carrot Edition"
+    slug: spice-of-life-carrot-edition
+    mr: 
+    cf: 277616
+  - name: "Storage Drawers"
+    slug: storagedrawers
+    mr: guitPqEi
+    cf: 
+  - name: "SuperMartijn642's Config Lib"
+    slug: supermartijn642s-config-lib
+    mr: LN9BxssP
+    cf: 
+  - name: "SuperMartijn642's Core Lib"
+    slug: supermartijn642s-core-lib
+    mr: rOUBggPv
+    cf: 
+  - name: "TerraBlender"
+    slug: terrablender
+    mr: kkmrDlKT
+    cf: 
+  - name: "The Afterdark"
+    slug: the-afterdark
+    mr: EjqfdsbN
+    cf: 
+  - name: "Thermal Dynamics"
+    slug: thermal-dynamics
+    mr: t8bmWGI2
+    cf: 
+  - name: "Thermal Expansion"
+    slug: thermal-expansion
+    mr: hmD6rrUJ
+    cf: 
+  - name: "Thermal Foundation"
+    slug: thermal-foundation
+    mr: Xvg6q5Wp
+    cf: 
+  - name: "Thermal Integration"
+    slug: thermal-integration
+    mr: Ro7yiyD4
+    cf: 
+  - name: "Tinkers' Construct"
+    slug: tinkers-construct
+    mr: rxIIYO6c
+    cf: 
+  - name: "Tinkers' Levelling Addon"
+    slug: tinkers-levelling-addon
+    mr: 
+    cf: 709416
+  - name: "Titanium"
+    slug: titanium
+    mr: 1Ro7m06l
+    cf: 
+  - name: "TorchMaster"
+    slug: torchmaster
+    mr: Tl8ESrhX
+    cf: 
+  - name: "Trample No More"
+    slug: trample-no-more
+    mr: 
+    cf: 377313
+  - name: "Trash Cans"
+    slug: trash-cans
+    mr: 4QrnfueM
+    cf: 
+  - name: "Waystones"
+    slug: waystones
+    mr: LOpKHB2A
+    cf: 
+  - name: "ZeroCore 2"
+    slug: zerocore
+    mr: 
+    cf: 247921

--- a/setup.sh
+++ b/setup.sh
@@ -9,6 +9,29 @@ OUT_DIR="$PWD"
 PACK_DIR="$OUT_DIR/$PACK_NAME"
 MRPACK="$OUT_DIR/${PACK_NAME}.mrpack"
 PW="packwiz -y"
+MODS_YAML="$OUT_DIR/mods.yaml"
+
+UPGRADE=0
+EXPORT=0
+
+usage() {
+  cat <<EOF
+Usage: ./setup.sh [--upgrade] [--export-mods]
+
+  --upgrade      Update all pinned mods to latest (re-adds each mod)
+  --export-mods  Generate mods.yaml from currently installed mods and exit
+EOF
+}
+
+for arg in "${@:-}"; do
+  case "$arg" in
+    --upgrade) UPGRADE=1 ;;
+    --export-mods) EXPORT=1 ;;
+    -h|--help) usage; exit 0 ;;
+    "") ;;
+    *) echo "Unknown arg: $arg"; usage; exit 1 ;;
+  esac
+done
 
 echo "==> Reset"
 rm -rf "$MRPACK"
@@ -17,14 +40,12 @@ cd "$PACK_DIR"
 
 if [[ ! -f "$PACK_DIR/pack.toml" ]]; then
     echo "==> Init pack ($MC_VERSION Forge $FORGE_VERSION)"
-    # Retry packwiz init on network failures (TLS handshake timeouts, etc.)
     init_success=false
     for attempt in 1 2; do
         if [[ $attempt -gt 1 ]]; then
             echo "    Init attempt $attempt/2 (network error, retrying...)"
             sleep 2
         fi
-        
         if $PW init \
           --name "$PACK_NAME" \
           --author "$AUTHOR" \
@@ -36,12 +57,10 @@ if [[ ! -f "$PACK_DIR/pack.toml" ]]; then
             break
         fi
     done
-
     if [[ "$init_success" != "true" ]]; then
         echo "ERROR: Failed to initialize pack after 2 attempts"
         exit 1
     fi
-
     echo "==> Accept MC $MC_VERSION family"
     $PW settings acceptable-versions --add 1.20
     $PW settings acceptable-versions --add 1.20.1
@@ -49,252 +68,128 @@ else
     echo "==> Pack already exists, skipping init"
 fi
 
-# Helper function - prefer Modrinth with CurseForge fallback with retry logic
-# Usage: add_mod "display-name" "slug" "modrinth-id" ["curseforge-id"]
-add_mod() {
-    local display_name="$1"
-    local slug="$2"
-    local modrinth_id="$3"
-    local curseforge_id="${4:-}"
-    local max_attempts=2
-    local attempt=1
-    
-    echo "Adding: $display_name ($slug)"
-    
-    # Helper function to attempt adding a mod with retry logic
-    try_add_with_retry() {
-        local add_command="$1"
-        local source_name="$2"
-        
-        for ((attempt=1; attempt<=max_attempts; attempt++)); do
-            if [[ $attempt -gt 1 ]]; then
-                local backoff_time=$((attempt - 1))
-                echo "    Retry attempt $attempt/$max_attempts (waiting ${backoff_time}s)..."
-                sleep $backoff_time
-            fi
-            
-            # Capture output and exit code, suppress output
-            local output
-            local exit_code
-            output=$(eval "$add_command" 2>&1)
-            exit_code=$?
-            
-            if [[ $exit_code -eq 0 ]]; then
-                echo "    ✓ $source_name"
-                return 0
-            fi
-            
-            # Only retry on network/connection errors, not "mod not found" errors
-            if [[ $output == *"network"* ]] || [[ $output == *"connection"* ]] || [[ $output == *"TLS"* ]] || [[ $output == *"timeout"* ]] || [[ $output == *"SSL"* ]]; then
-                if [[ $attempt -lt $max_attempts ]]; then
-                    echo "    $source_name network error, retrying..."
-                else
-                    echo "    ✗ $source_name (network error)"
-                fi
-            else
-                # For non-network errors, fail silently since export may still work
-                return 1
-            fi
-        done
-        
-        return 1
-    }
-    
-    # Try Modrinth first (preferred)
-    if [[ -n "$modrinth_id" ]]; then
-        if try_add_with_retry "$PW modrinth add '$modrinth_id'" "MR"; then
-            return 0
-        fi
-    fi
-    
-    # Fallback to CurseForge
-    if [[ -n "$curseforge_id" ]]; then
-        # Try as project ID first, then as slug if that fails
-        if try_add_with_retry "$PW curseforge add '$curseforge_id'" "CF" || \
-           try_add_with_retry "$PW curseforge add '$slug'" "CF"; then
-            return 0
-        fi
-    fi
-    
-    # Always return success so script continues
-    return 0
+# Locate mod file by update id
+find_mod_file_by_mr() {
+  local mr_id="$1"
+  grep -RIl --null -- "mod-id = \"$mr_id\"" "$PACK_DIR/mods" 2>/dev/null | tr -d '\0' | head -n1 || true
 }
 
-echo "==> Core compute / storage / power"
-add_mod "OpenComputers 2 Reimagined" "oc2r" "F1gm4RsH" "864686"           # Programmable computers with Lua
-add_mod "Refined Storage" "refined-storage" "KDvYkUg3" "243076"             # Digital storage system
-add_mod "Extra Storage" "extrastorage" "T34cBZKl" "404074"                 # RS addon for larger disks
-add_mod "Storage Drawers" "storagedrawers" "guitPqEi" "223852"              # Compact item storage blocks
-add_mod "Iron Chests" "iron-chests" "P3iIrPH3" "228756"                     # Upgraded chest variants
-add_mod "Mekanism" "mekanism" "Ce6I4WUE" "268560"                           # Tech mod with ore processing
-add_mod "Mekanism Generators" "mekanism-generators" "OFVYKsAk" "268566"   # Power generation for Mekanism
-add_mod "Ender IO" "ender-io" "enderio" "64578"                          # Conduits and advanced machines (beta but functional)
-add_mod "Industrial Foregoing" "industrial-foregoing" "industrial-foregoing" "266515"         # Automation and mob farming
+find_mod_file_by_cf() {
+  local cf_proj="$1"
+  grep -RIl --null -- "project-id = $cf_proj" "$PACK_DIR/mods" 2>/dev/null | tr -d '\0' | head -n1 || true
+}
 
-echo "==> World / magic / QoL"
-add_mod "Botania" "botania" "pfjLUfGv" "225643"                             # Nature magic mod
-add_mod "Biomes O' Plenty" "biomes-o-plenty" "HXF82T3G" "220318"           # Additional biomes
-add_mod "Flat Bedrock" "flat-bedrock" "" "398623"                           # Flat bedrock generation for easier Grains of Infinity
-add_mod "Waystones" "waystones" "LOpKHB2A" "245755"                         # Fast travel waypoints
-add_mod "Nature's Compass" "natures-compass" "fPetb5Kh" "252848"            # Biome locator
-add_mod "Explorer's Compass" "explorers-compass" "RV1qfVQ8" "313536"       # Structure locator
-add_mod "Just Enough Items" "jei" "u6dRKJwZ" "238222"                       # Recipe viewer
-add_mod "Just Enough Resources" "just-enough-resources-jer" "just-enough-resources-jer" "240630"    # JEI addon for ore info
-add_mod "Jade" "jade" "nvQzSEkH" "324717"                                   # Block/entity info overlay
-add_mod "Mouse Tweaks" "mouse-tweaks" "aC3cM3Vq" "60089"                   # Inventory mouse improvements
-add_mod "JourneyMap" "journeymap" "lfHFW1mp" "32274"                       # Minimap and waypoints
-add_mod "Fast Leaf Decay" "fast-leaf-decay" "fld" "230976"                   # Faster tree cleanup
+# Fallback: locate by slug filename
+find_mod_file_by_slug() {
+  local slug="$1"
+  local cand="$PACK_DIR/mods/${slug}.pw.toml"
+  [[ -f "$cand" ]] && echo "$cand" || true
+}
 
-echo "==> Immersive Engineering"
-add_mod "Immersive Engineering" "immersive-engineering" "immersiveengineering" "231951"        # Multiblock machines and tech
+# Add a mod with retry; prefer Modrinth then CurseForge
+add_mod_with_retry() {
+  local name="$1"; local slug="$2"; local mr="$3"; local cf="$4"
+  local max_attempts=2
+  echo "Adding: $name ($slug)"
+  local attempt output exit_code
+  if [[ -n "$mr" ]]; then
+    for ((attempt=1; attempt<=max_attempts; attempt++)); do
+      [[ $attempt -gt 1 ]] && echo "    Retry MR $attempt/$max_attempts..." && sleep $((attempt-1))
+      output=$($PW modrinth add "$mr" 2>&1) && { echo "    ✓ MR"; return 0; } || exit_code=$?
+      if [[ "$output" == *network* || "$output" == *connection* || "$output" == *TLS* || "$output" == *timeout* || "$output" == *SSL* ]]; then
+        continue
+      else
+        break
+      fi
+    done
+  fi
+  if [[ -n "$cf" ]]; then
+    for ((attempt=1; attempt<=max_attempts; attempt++)); do
+      [[ $attempt -gt 1 ]] && echo "    Retry CF $attempt/$max_attempts..." && sleep $((attempt-1))
+      output=$($PW curseforge add "$cf" 2>&1) && { echo "    ✓ CF (id)"; return 0; } || true
+      output=$($PW curseforge add "$slug" 2>&1) && { echo "    ✓ CF (slug)"; return 0; } || true
+    done
+  fi
+  return 0
+}
 
-echo "==> Mystical Agriculture"
-add_mod "Cucumber Library" "cucumber" "cucumber" "272335"                           # Required library
-add_mod "Mystical Agriculture" "mystical-agriculture" "C95ReXie" "246640"  # Grow resources with crops
-add_mod "Mystical Agradditions" "mystical-agradditions" "pl0jGXIx" "256247" # Extra high-tier seeds
+process_mod() {
+  local name="$1" slug="$2" mr="$3" cf="$4"
+  local modfile=""
+  if [[ -n "$mr" ]]; then
+    modfile=$(find_mod_file_by_mr "$mr") || true
+  fi
+  if [[ -z "$modfile" && -n "$cf" ]]; then
+    modfile=$(find_mod_file_by_cf "$cf") || true
+  fi
+  if [[ -z "$modfile" && -n "$slug" ]]; then
+    modfile=$(find_mod_file_by_slug "$slug") || true
+  fi
+  if [[ -n "$modfile" && $UPGRADE -eq 0 ]]; then
+    echo "    ✓ Present (pinned): $name"
+    return 0
+  fi
+  if [[ -n "$modfile" && $UPGRADE -eq 1 ]]; then
+    echo "    ~ Upgrading: $name"
+    rm -f "$modfile"
+  fi
+  add_mod_with_retry "$name" "$slug" "$mr" "$cf"
+}
 
-echo "==> Inventory QoL: Dank-like storage & magnets"
-add_mod "Dank Storage" "dank-storage" "" "225469"                          # Portable filtered storage
-add_mod "Sophisticated Backpacks" "sophisticated-backpacks" "TyCTlI4b" "422301" # Advanced backpacks with upgrades
-add_mod "Item Collectors" "item-collectors" "y9vDr4Th" "330482"            # Vacuum blocks for automation
+export_mods_yaml() {
+  echo "mods:" > "$MODS_YAML"
+  for f in "$PACK_DIR"/mods/*.pw.toml; do
+    [[ -e "$f" ]] || continue
+    local name slug mr cf proj fileid
+    name=$(grep -m1 '^name = ' "$f" | sed 's/^name = \"\(.*\)\"/\1/')
+    slug=$(basename "$f" | sed 's/\.pw\.toml$//')
+    mr=$(awk '/\[update.modrinth\]/{flag=1;next}/\[/{flag=0}flag && /mod-id =/{gsub(/.*= \"|\"/,"",$0);print $0}' "$f" || true)
+    proj=$(awk '/\[update.curseforge\]/{flag=1;next}/\[/{flag=0}flag && /project-id =/{gsub(/.*= /,"",$0);print $0}' "$f" || true)
+    fileid=$(awk '/\[update.curseforge\]/{flag=1;next}/\[/{flag=0}flag && /file-id =/{gsub(/.*= /,"",$0);print $0}' "$f" || true)
+    cf="$proj"
+    printf "  - name: \"%s\"\n    slug: %s\n    mr: %s\n    cf: %s\n" "$name" "$slug" "${mr:-}" "${cf:-}" >> "$MODS_YAML"
+  done
+  echo "==> Wrote $MODS_YAML"
+}
 
-echo "==> Mob farming utilities"
-add_mod "Mob Grinding Utils" "mob-grinding-utils" "" "314906"             # Mob farm blocks and tools
+if [[ $EXPORT -eq 1 ]]; then
+  echo "==> Exporting installed mods to mods.yaml"
+  export_mods_yaml
+  exit 0
+fi
 
-echo "==> RFTools"
-add_mod "RFTools Base" "rftools-base" "rftools-base" "326041"                          # Core RFTools library
-add_mod "RFTools Builder" "rftools-builder" "rftools-builder" "275376"                    # Quarry and building tools
-add_mod "RFTools Control" "rftools-control" "rftools-control" "385194"                   # Computer control systems
-add_mod "RFTools Dimensions" "rftools-dimensions" "rftools-dimensions" "343887"              # Custom dimension creation
-add_mod "RFTools Power" "rftools-power" "rftools-power" "326043"                       # Power generation
-add_mod "RFTools Storage" "rftools-storage" "" "326045"                   # Modular storage system
-add_mod "RFTools Utility" "rftools-utility" "rftools-utility" "326044"                   # Utility blocks
+if [[ ! -f "$MODS_YAML" ]]; then
+  echo "ERROR: mods.yaml not found at $MODS_YAML"
+  echo "Hint: run './setup.sh --export-mods' to bootstrap from current pack."
+  exit 1
+fi
 
-echo "==> Exploration / adventure"
-add_mod "Cucumber Library" "cucumber" "cucumber" "272335"                           # Library (duplicate but needed)
-add_mod "Iron Jetpacks" "iron-jetpacks" "iron-jetpacks" "253560"                       # Tiered flight packs
-
-echo "==> Mining dimension"
-add_mod "Advanced Mining Dimension" "advanced-mining-dimension" "advanced-mining-dimension" "384976" # Separate mining world
-
-add_mod "Chipped" "chipped" "BAscRYKm" "456956"                             # Decorative block variants
-add_mod "CodeChicken Lib 1.8" "codechicken-lib-1-8" "codechicken-lib" "242818"          # Legacy library
-add_mod "EnderStorage 1.8" "ender-storage-1-8" "ender-storage" "245174"               # Cross-dimensional storage
-add_mod "Flux Networks" "flux-networks" "" "248020"                       # Wireless power networks
-
-echo "==> Core food/cooking"
-add_mod "Croptopia" "croptopia" "" "415438"                                 # Expanded food system
-add_mod "Farmer's Delight" "farmers-delight" "farmers-delight" "398521"                   # Enhanced farming and cooking
-add_mod "Cooking for Blockheads" "cooking-for-blockheads" "cooking-for-blockheads" "231484"     # Kitchen multiblocks
-add_mod "AppleSkin" "appleskin" "appleskin" "248787"                                # Food/hunger info overlay
-add_mod "Nether's Delight" "nethers-delight" "" "624489"                  # Nether-themed foods
-add_mod "End's Delight" "ends-delight" "" "638577"                         # End-themed foods
-
-add_mod "Reap Mod" "reap" "NYHbcKK1" "225833"                               # Right-click crop harvesting
-add_mod "Snad" "snad" "" "319121"                                           # Faster cactus/sugarcane growth
-add_mod "Bookshelf" "bookshelf" "" "228525"                                 # Library for Trample No More
-add_mod "Trample No More" "trample-no-more" "" "377313"                     # Farmland trampling protection
-
-echo "==> Thermal Series"
-add_mod "CoFH Core" "cofh-core" "cofh-core" "69162"                                  # Thermal foundation
-add_mod "Thermal Foundation" "thermal-foundation" "thermal-foundation" "222880"              # Base thermal mod
-add_mod "Thermal Expansion" "thermal-expansion" "thermal-expansion" "69163"                 # Machines and processing
-add_mod "Thermal Dynamics" "thermal-dynamics" "thermal-dynamics" "227443"                  # Ducts for items/energy/fluids
-add_mod "Thermal Integration" "thermal-integration" "thermal-integration" "291737"            # Cross-mod integration
-
-
-
-echo "==> Builder wands"
-add_mod "Construction Wand" "construction-wand" "construction-wand" "284074"                 # Multi-block building tool
-
-echo "==> Tinkers"
-add_mod "Tinkers' Construct" "tinkers-construct" "rxIIYO6c" "74072"         # Tool crafting and customization
-add_mod "Tinkers Levelling Addon" "tinkers-levelling-addon" "" "644662"    # XP progression for tools
-
-add_mod "Torchmaster" "torchmaster" "torchmaster" "269849"                             # Torch placement and mob spawning control
-
-echo "==> Mob synthesis (Hostile Neural Networks)"
-add_mod "Placebo" "placebo" "placebo" "283644"                                     # Required library
-add_mod "Hostile Neural Networks" "hostile-neural-networks" "" "377196"   # Mob data and simulation
-
-echo "==> Draconic Evolution"
-add_mod "Draconic Evolution" "draconic-evolution" "" "223565"              # End-game power and tools
-add_mod "Brandon's Core" "brandons-core" "" "231382"                       # Required library
-add_mod "Draconic Additions" "draconicadditions" "" "314515"             # Adds missing chaotic/awakened armor
-
-echo "==> Forestry & bee genetics"
-add_mod "Forestry Community Edition" "forestry-community-edition" "2oORTOi2" "882938" # Trees and bees
-add_mod "Gendustry Community Edition" "gendustry-community-edition" "2zkSGMyK" "882940" # Advanced bee breeding
-
-echo "==> Quality of life additions"
-add_mod "Default Options" "default-options" "IWe7P9UP" "232131"            # Ship default options and keybindings
-add_mod "OpenLoader" "open-loader" "dWV6rGSH" "226447"                      # Automatic datapack/resource pack loading
-add_mod "Paragliders" "paragliders" "esqWA0aQ" "328301"                     # Hang gliders for exploration
-add_mod "mmmmmmmmmmmm" "mmmmmmmmmmmm" "mmmmmmmmmmmm" ""                   # Target dummy for combat testing
-add_mod "Clean Swing Through Grass" "clean-swing-through-grass" "" "386549" # Attack through plants
-add_mod "Cobble For Days" "cobblefordays" "hi71AUZ0" "351748"              # Tiered cobblestone generators
-add_mod "Compact Machines" "compact-machines" "" "224218"                  # Pocket dimension rooms
-add_mod "Easy Villagers" "easy-villagers" "easy-villagers" "400514"                     # Portable villager management
-add_mod "Easy Piglins" "easy-piglins" "easy-piglins" "398578"                          # Portable piglin bartering
-add_mod "FindMe" "findme" "rEuzehyH" "291936"                               # Highlight items in chests
-add_mod "FTB Backups 2" "ftb-backups-2" "" "309674"                        # Automatic world backups
-
-echo "==> FTB Teams + Chunkloading"
-add_mod "Architectury API" "architectury-api" "architectury-api" "419699"                   # Cross-platform mod library
-add_mod "FTB Library" "ftb-library-forge" "" "404465"                      # Core FTB functionality
-add_mod "FTB Teams" "ftb-teams-forge" "" "404468"                          # Team management system
-add_mod "FTB Chunks" "ftb-chunks-forge" "" "314906"                        # Chunk claiming and loading
-add_mod "FTB Essentials" "ftb-essentials" "" "386134"                      # Home/TPA commands
-
-echo "==> Additional utilities"
-add_mod "Light Overlay" "light-overlay" "YfOlc91N" "325492"                 # Mob spawn light level overlay
-add_mod "Modular Routers" "modular-routers" "EuTS81Z3" "250294"            # Item routing and automation
-add_mod "Elevator Mod" "elevatormod" "hi2dSXTu" "250832"                   # Multi-floor elevators
-add_mod "Pylons" "pylons" "pylons" "219758"                                       # Wireless item transfer
-
-echo "==> Powah (Power system)"
-add_mod "Powah Rearchitected" "powah-rearchitected" "powah" "440979"             # Energy generation and storage
-add_mod "Cloth Config API" "cloth-config" "cloth-config" "348521"                      # Configuration library
-add_mod "GuideMe" "guideme" "Ck4E7v7R" "457134"                             # In-game guide system
-
-echo "==> Utility systems"
-add_mod "SuperMartijn642's Core Lib" "supermartijn642s-core-lib" "rOUBggPv" "454372" # Library
-add_mod "Trash Cans" "trash-cans" "4QrnfueM" "283995"                       # Disposal for items/fluids/energy
-add_mod "The Afterdark" "the-afterdark" "EjqfdsbN" "502372"                # Night-focused content
-add_mod "Controlling" "controlling" "xv94TkTM" "250398"                    # Keybind conflict management
-
-echo "==> Core technology mods"
-add_mod "Crafting Station" "crafting-station" "25IAE8wS" "272407"           # Extended crafting table
-add_mod "Applied Energistics 2" "ae2" "XxWD5pD3" "223794"                 # Digital storage and autocrafting
-add_mod "Cyclic" "cyclic" "cyclic" "239286"                                       # Utility blocks and tools
-
-echo "==> Botany and Create"
-add_mod "Botany Pots" "botany-pots" "U6BUTZ7K" "400975"                     # Compact crop growing
-add_mod "Botany Trees" "botany-trees" "mvs7RoIW" "577420"                  # Tree growing in pots
-add_mod "Create" "create" "create" "328085"                                         # Mechanical contraptions
-add_mod "Create Ore Excavation" "create-ore-excavation" "" "724426"       # Large-scale mining
-
-echo "==> Specialized crops and storage"
-add_mod "Ender Crop" "ender-crop" "" "455826"                              # Teleporting crop items
-add_mod "Spice of Life: Carrot Edition" "spice-of-life-carrot-edition" "" "277616" # Food variety rewards
-add_mod "Inventory Sorter" "inventory-sorter" "" "327266"                 # Auto-sorting inventory
-add_mod "Pipez" "pipez" "iRmWy6ga" "443900"                                 # Simple item/fluid/energy pipes
-add_mod "AllTheCompressed" "allthecompressed" "" "317269"                 # Compressed storage blocks
-
-echo "==> Gravestones"
-add_mod "Gravestone Mod" "gravestone" "RYtXKJPr" "238551"                   # Death recovery system
-
-echo "==> Reactors"
-add_mod "ZeroCore 2" "zerocore" "" "267602"                                # Multiblock reactor library
-add_mod "Extreme Reactors" "extreme-reactors" "" "250277"                  # Big Reactors successor
-
-echo "==> Mining QoL"
-add_mod "FTB Library" "ftb-library-forge" "" "404465"                      # Library (duplicate)
-add_mod "FTB Ultimine" "ftb-ultimine-forge" "" "386135"                   # Veinmining functionality
-
-echo "==> Shaders / renderer"
-add_mod "Oculus" "oculus" "oculus" "581495"                                       # Shader support for Forge
-add_mod "Embeddium" "embeddium" "embeddium" "908741"                                # Performance renderer (NOT Rubidium)
+echo "==> Ensuring mods from mods.yaml (upgrade=$UPGRADE)"
+current_key=""; name=""; slug=""; mr=""; cf=""; have_record=0
+while IFS= read -r line || [[ -n "$line" ]]; do
+  trimmed="$(echo "$line" | sed 's/^\s*//')"
+  [[ -z "$trimmed" ]] && continue
+  [[ "$trimmed" =~ ^# ]] && continue
+  if [[ "$trimmed" == -* ]]; then
+    if [[ $have_record -eq 1 ]]; then
+      process_mod "$name" "$slug" "$mr" "$cf"
+    fi
+    name=""; slug=""; mr=""; cf=""; have_record=1
+    continue
+  fi
+  key="${trimmed%%:*}"
+  val="${trimmed#*:}"
+  val="$(echo "$val" | sed 's/^\s*//; s/^\"//; s/\"$//')"
+  case "$key" in
+    name) name="$val" ;;
+    slug) slug="$val" ;;
+    mr) mr="$val" ;;
+    cf) cf="$val" ;;
+  esac
+done < "$MODS_YAML"
+if [[ $have_record -eq 1 ]]; then
+  process_mod "$name" "$slug" "$mr" "$cf"
+fi
 
 echo "==> Refresh index"
 $PW refresh


### PR DESCRIPTION
This PR refactors the pack build flow to make mod versions stable by default and only update on request.

Key changes
- Introduce mods.yaml as the single declarative mods list (name, slug, MR id, CF project id)
- Rewrite setup.sh to read mods.yaml and ensure mods are installed
- Default run keeps current pinned versions (no auto-updates)
- Add --upgrade flag to re-resolve and update all mod pins
- Add --export-mods to generate mods.yaml from current installed pins
- Update README and CLAUDE.md with the new workflow

Behavior
- Pins live in cwagecraft/mods/*.pw.toml ([update.modrinth] version or [update.curseforge] file-id)
- Normal run: leaves existing pins untouched; only adds missing mods
- --upgrade: removes existing .pw.toml entries and re-adds to update pins
- Export still includes any config changes even when no mods change

Follow-ups (optional)
- Add a --validate mode to show per-mod detection status and mismatches
- Allow explicit version pins in mods.yaml for true “vendor lock”, when desired