### PR TITLE
Disable Platinum jetpack tier and hide broken recipes (fixes #41)

### DIFF
--- a/cwagecraft/config/ironjetpacks/jetpacks/platinum.json
+++ b/cwagecraft/config/ironjetpacks/jetpacks/platinum.json
@@ -1,0 +1,26 @@
+{
+  "name": "platinum",
+  "disable": true,
+  "tier": 4,
+  "color": "a6e9ff",
+  "armorPoints": 4,
+  "enchantability": 12,
+  "craftingMaterial": "tag:forge:ingots/platinum",
+  "creative": false,
+  "rarity": 0,
+  "toughness": 0.0,
+  "knockbackResistance": 0.0,
+  "curios": true,
+  "capacity": 36000000,
+  "usage": 720,
+  "speedVertical": 0.92,
+  "accelVertical": 0.155,
+  "speedSideways": 0.193,
+  "speedHoverAscend": 0.42,
+  "speedHoverDescend": 0.25,
+  "speedHover": 0.005,
+  "sprintSpeedMulti": 1.8,
+  "sprintSpeedMultiVertical": 1.4,
+  "sprintFuelMulti": 3.8
+}
+

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -13,6 +13,10 @@ file = "config/ftb-ultimine-forge.toml"
 hash = "346e63db210e2a2bd87504728adbef9a782d86b1aa462fe34b35372aece5c405"
 
 [[files]]
+file = "config/ironjetpacks/jetpacks/platinum.json"
+hash = "d62a55becd3bd9008288c538708f0cfabb94bf508fd5ff38a90d168ce35747e5"
+
+[[files]]
 file = "config/oculus.properties"
 hash = "a8230edabb98fbbe0b6a35a40fa85bb546c5a3334ae54e0721e0356b1bd6693e"
 
@@ -585,8 +589,16 @@ file = "defaultconfigs/pylons-server.toml"
 hash = "51d076ed014be250278963cd6d04910baaf8b08c0d14e017d6d76e3cb3d2578c"
 
 [[files]]
+file = "kubejs/client_scripts/hide_platinum_jetpack_jei.js"
+hash = "553a625fb6cbbe529a4e00ad3a85b4470e2291dbeb2b03a90378b2a49bc401c0"
+
+[[files]]
 file = "kubejs/client_scripts/jei_fusion_unhide.js"
 hash = "a9794c0a78d62d3f628052aef13ca1b609dd64e28de7173c321472cccbfc9b0a"
+
+[[files]]
+file = "kubejs/server_scripts/disable_platinum_jetpack.js"
+hash = "9fff6c72c629326f2cbd018de485200d65189e6c4e5e677b33afa94189aac149"
 
 [[files]]
 file = "mods/advanced-mining-dimension.pw.toml"

--- a/cwagecraft/kubejs/client_scripts/hide_platinum_jetpack_jei.js
+++ b/cwagecraft/kubejs/client_scripts/hide_platinum_jetpack_jei.js
@@ -1,0 +1,11 @@
+// Hide Platinum jetpack and related platinum placeholders from JEI
+// Helps avoid showing broken recipes/items due to missing platinum
+
+JEIEvents.hideItems(event => {
+  // Hide any Iron Jetpacks item that references platinum by id
+  event.hide(/ironjetpacks:.*platinum.*/);
+
+  // Also hide the empty platinum ingot tag placeholder if it shows up
+  event.hide('#forge:ingots/platinum');
+});
+

--- a/cwagecraft/kubejs/server_scripts/disable_platinum_jetpack.js
+++ b/cwagecraft/kubejs/server_scripts/disable_platinum_jetpack.js
@@ -1,0 +1,14 @@
+// Disable Platinum jetpack recipes from Iron Jetpacks to avoid confusion
+// Removes any recipe whose ID or output contains "platinum" in the ironjetpacks namespace.
+
+ServerEvents.recipes(event => {
+  // Remove by explicit recipe id pattern
+  event.remove({ id: /ironjetpacks:.*platinum.*/ });
+
+  // Remove by output pattern as a fallback (covers potential naming differences)
+  event.remove({ output: /ironjetpacks:.*platinum.*/ });
+
+  // Remove any recipe that uses the platinum ingot tag
+  // This ensures broken platinum-dependent recipes do not appear in JEI
+  event.remove({ input: '#forge:ingots/platinum' });
+});

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "14ef8325a9fe4649e585beedb5ae9aac8f2a99a37d45a2aceb85ed5f31419cc3"
+hash = "bf58a1b779e694bd901969c3fb753252030dd6699c0b023f619e43851cb68210"
 
 [versions]
 forge = "47.3.22"


### PR DESCRIPTION
Problem
- Issue #41: JEI shows Empty tag: forge:ingots/platinum and Iron Jetpacks Platinum tier recipe appears broken due to missing platinum source.

What changed
- KubeJS server: remove any ironjetpacks:*platinum* recipes and any recipe using #forge:ingots/platinum.
- KubeJS client: hide ironjetpacks platinum items and the empty platinum tag from JEI.
- Iron Jetpacks config: add platinum.json override with "disable": true to ensure the Platinum tier is disabled across installs/resets.

Why this approach
- We intentionally avoid adding a platinum provider to keep the pack lean and because platinum isn’t needed for Thermal Enderium in 1.20.x.
- Disabling the tier removes a confusing/broken recipe while leaving other jetpack tiers intact (Diamond T4 and Emerald T5 cover and exceed that tier).

Verification
- Rebuilt pack and imported .mrpack; Platinum jetpack no longer appears, recipe removed/hidden; logs show KubeJS scripts loaded without errors related to this change.

Notes
- Some unrelated KubeJS warnings originate from AllTheCompressed filters referencing non-installed mods; these are existing and do not affect this fix.