### PR TITLE
Rebalance Draconium ore rates; add verification features

### DIFF
--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/forge/biome_modifier/add_draconium_overworld_lower_mid.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/forge/biome_modifier/add_draconium_overworld_lower_mid.json
@@ -1,0 +1,7 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": "cwagecraft:overworld_draconium_ore_lower_mid",
+  "step": "underground_ores"
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/forge/biome_modifier/add_draconium_overworld_upper.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/forge/biome_modifier/add_draconium_overworld_upper.json
@@ -1,0 +1,7 @@
+{
+  "type": "forge:add_features",
+  "biomes": "#minecraft:is_overworld",
+  "features": "cwagecraft:overworld_draconium_ore_upper",
+  "step": "underground_ores"
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/overworld_draconium_ore_lower_mid.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/overworld_draconium_ore_lower_mid.json
@@ -1,0 +1,17 @@
+{
+  "feature": "draconicevolution:overworld_draconium_ore",
+  "placement": [
+    { "type": "minecraft:count", "count": 30 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": -64 },
+        "max_inclusive": { "absolute": 56 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/overworld_draconium_ore_upper.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/overworld_draconium_ore_upper.json
@@ -1,0 +1,17 @@
+{
+  "feature": "draconicevolution:overworld_draconium_ore",
+  "placement": [
+    { "type": "minecraft:count", "count": 8 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": 80 },
+        "max_inclusive": { "absolute": 256 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/test_overworld_draconium_ore.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/cwagecraft/worldgen/placed_feature/test_overworld_draconium_ore.json
@@ -1,0 +1,17 @@
+{
+  "feature": "draconicevolution:overworld_draconium_ore",
+  "placement": [
+    { "type": "minecraft:count", "count": 24 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": -64 },
+        "max_inclusive": { "absolute": -48 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/end_draconium_ore.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/end_draconium_ore.json
@@ -1,0 +1,17 @@
+{
+  "feature": "draconicevolution:end_draconium_ore",
+  "placement": [
+    { "type": "minecraft:count", "count": 12 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": 0 },
+        "max_inclusive": { "absolute": 70 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/nether_draconium_ore.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/nether_draconium_ore.json
@@ -1,0 +1,17 @@
+{
+  "feature": "draconicevolution:nether_draconium_ore",
+  "placement": [
+    { "type": "minecraft:rarity_filter", "chance": 16 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": 4 },
+        "max_inclusive": { "absolute": 16 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}
+

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/overworld_draconium_ore.json
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/data/draconicevolution/worldgen/placed_feature/overworld_draconium_ore.json
@@ -1,0 +1,16 @@
+{
+  "feature": "draconicevolution:overworld_draconium_ore",
+  "placement": [
+    { "type": "minecraft:rarity_filter", "chance": 48 },
+    { "type": "minecraft:in_square" },
+    {
+      "type": "minecraft:height_range",
+      "height": {
+        "type": "minecraft:uniform",
+        "min_inclusive": { "absolute": -64 },
+        "max_inclusive": { "absolute": -40 }
+      }
+    },
+    { "type": "minecraft:biome" }
+  ]
+}

--- a/cwagecraft/config/openloader/data/de_ore_rates_revelation/pack.mcmeta
+++ b/cwagecraft/config/openloader/data/de_ore_rates_revelation/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "Adjust DE draconium ore rates to approximate FTB Revelation: OW very rare, Nether uncommon, End plentiful."
+  }
+}
+


### PR DESCRIPTION
This PR adjusts Draconic Evolution ore generation to match Revelation-like feel and adds helper features for quick verification.\n\nChanges:\n- Override DE placed_feature rates:\n  - End: 12 veins/chunk @ Y 0..70\n  - Nether: 1-in-16 rarity @ Y 4..16\n  - Overworld: 1-in-48 rarity @ Y -64..-40\n- Add cwagecraft features + biome modifiers to temporarily make Overworld draconium unmistakable for testing:\n  - cwagecraft:overworld_draconium_ore_lower_mid (count 30, Y -64..56)\n  - cwagecraft:overworld_draconium_ore_upper (count 8, Y 80..256)\n- Comets unchanged.\n\nNotes:\n- Only affects new chunks.\n- We can dial back the cwagecraft features after validation.\n