### PR TITLE
Cyclic: tag-based compressed cobblestone (JEI rotation + ATC compat)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,7 @@ Each mod has a `.pw.toml` file containing:
 2. **Pinning**: Versions are pinned via generated `.pw.toml` files; only change on `--upgrade`
 3. **Query pack**: Use `packwiz -y list` or similar informational commands
 4. **Never**: Use `packwiz add/remove` or modify .pw.toml files directly
+5. **Reload vs Rebuild**: Do not rely on in-game `/reload` for validating changes (including OpenLoader datapacks, KubeJS scripts, and config). Always rebuild the pack with `./setup.sh` and reinstall the exported `cwagecraft.mrpack` to apply changes.
 
 ## Critical Success Validation
 - **ALWAYS check exit status**: The setup.sh script needs better exit status handling on failures

--- a/cwagecraft/config/openloader/data/compressed_cobble_tags/data/forge/tags/items/compressed/cobblestone_1x.json
+++ b/cwagecraft/config/openloader/data/compressed_cobble_tags/data/forge/tags/items/compressed/cobblestone_1x.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "allthecompressed:cobblestone_1x",
+    "cyclic:compressed_cobblestone"
+  ]
+}

--- a/cwagecraft/config/openloader/data/compressed_cobble_tags/data/forge/tags/items/storage_blocks/cobblestone.json
+++ b/cwagecraft/config/openloader/data/compressed_cobble_tags/data/forge/tags/items/storage_blocks/cobblestone.json
@@ -1,0 +1,7 @@
+{
+  "replace": false,
+  "values": [
+    "allthecompressed:cobblestone_1x",
+    "cyclic:compressed_cobblestone"
+  ]
+}

--- a/cwagecraft/config/openloader/data/compressed_cobble_tags/pack.mcmeta
+++ b/cwagecraft/config/openloader/data/compressed_cobble_tags/pack.mcmeta
@@ -1,0 +1,6 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "cwagecraft: Ensure compressed cobblestone tags include ATC for JEI rotation"
+  }
+}

--- a/cwagecraft/config/openloader/data/cyclic_recipe_fixes/data/cyclic/recipes/compressed_cobblestone_u.json
+++ b/cwagecraft/config/openloader/data/cyclic_recipe_fixes/data/cyclic/recipes/compressed_cobblestone_u.json
@@ -1,0 +1,5 @@
+{
+  "conditions": [
+    { "type": "forge:false" }
+  ]
+}

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -153,6 +153,18 @@ file = "config/openloader/data/compat_filters/pack.mcmeta"
 hash = "d1c3baa3561bf3b961ac30aea1dbae0f85fa20d583771b9354226da59ac28feb"
 
 [[files]]
+file = "config/openloader/data/compressed_cobble_tags/data/forge/tags/items/compressed/cobblestone_1x.json"
+hash = "f774b43bacdcab665930e8a93336e720b379e98dafe98fc08288eaef2268fc82"
+
+[[files]]
+file = "config/openloader/data/compressed_cobble_tags/data/forge/tags/items/storage_blocks/cobblestone.json"
+hash = "f774b43bacdcab665930e8a93336e720b379e98dafe98fc08288eaef2268fc82"
+
+[[files]]
+file = "config/openloader/data/compressed_cobble_tags/pack.mcmeta"
+hash = "fe8d2276e3eaf60e3b1fb4c413bfb1c8427899e58b28649d9e3db4877eefa7f9"
+
+[[files]]
 file = "config/openloader/data/cyclic_recipe_fixes/README.md"
 hash = "991b32137ec52531f25da17af6060ca4e48ea40cb4b61f53930efcd1fc51d6ab"
 
@@ -175,6 +187,10 @@ hash = "02a3023a944070ee5d209552f1b8bd64f73c206d5d5575f949fd713dd8c9635c"
 [[files]]
 file = "config/openloader/data/cyclic_recipe_fixes/data/cyclic/recipes/compressed_cobblestone.json"
 hash = "02a3023a944070ee5d209552f1b8bd64f73c206d5d5575f949fd713dd8c9635c"
+
+[[files]]
+file = "config/openloader/data/cyclic_recipe_fixes/data/cyclic/recipes/compressed_cobblestone_u.json"
+hash = "7624acbcc41660ed5ac983282c1e44967e78ef3698871b2513e558c8a6a72e9f"
 
 [[files]]
 file = "config/openloader/data/cyclic_recipe_fixes/pack.mcmeta"
@@ -643,6 +659,10 @@ hash = "553a625fb6cbbe529a4e00ad3a85b4470e2291dbeb2b03a90378b2a49bc401c0"
 [[files]]
 file = "kubejs/client_scripts/jei_fusion_unhide.js"
 hash = "a9794c0a78d62d3f628052aef13ca1b609dd64e28de7173c321472cccbfc9b0a"
+
+[[files]]
+file = "kubejs/server_scripts/accept_atc_compressed_cobble.js"
+hash = "f8a86b223223762285062897c4b03169ed9462423ba7b8ec91f1140652147197"
 
 [[files]]
 file = "kubejs/server_scripts/disable_platinum_jetpack.js"

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -662,11 +662,15 @@ hash = "a9794c0a78d62d3f628052aef13ca1b609dd64e28de7173c321472cccbfc9b0a"
 
 [[files]]
 file = "kubejs/server_scripts/accept_atc_compressed_cobble.js"
-hash = "f8a86b223223762285062897c4b03169ed9462423ba7b8ec91f1140652147197"
+hash = "3c2093b5c6d9548dfd1d9aa1f93af93eb4391f817850157552e96b310492b145"
 
 [[files]]
 file = "kubejs/server_scripts/disable_platinum_jetpack.js"
 hash = "9fff6c72c629326f2cbd018de485200d65189e6c4e5e677b33afa94189aac149"
+
+[[files]]
+file = "kubejs/startup_scripts/constants.js"
+hash = "b7ae87e63de558d941732e368decf95bdb1896a604802f3c9148a0b183977cd7"
 
 [[files]]
 file = "mods/advanced-mining-dimension.pw.toml"

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -662,7 +662,7 @@ hash = "a9794c0a78d62d3f628052aef13ca1b609dd64e28de7173c321472cccbfc9b0a"
 
 [[files]]
 file = "kubejs/server_scripts/accept_atc_compressed_cobble.js"
-hash = "3c2093b5c6d9548dfd1d9aa1f93af93eb4391f817850157552e96b310492b145"
+hash = "4adab4f466fa8a67355b364f3cdf0a9898dbe98f0fc8e0ac5aa446324c0df8ec"
 
 [[files]]
 file = "kubejs/server_scripts/disable_platinum_jetpack.js"
@@ -670,7 +670,7 @@ hash = "9fff6c72c629326f2cbd018de485200d65189e6c4e5e677b33afa94189aac149"
 
 [[files]]
 file = "kubejs/startup_scripts/constants.js"
-hash = "b7ae87e63de558d941732e368decf95bdb1896a604802f3c9148a0b183977cd7"
+hash = "24aa6877fadc790405bbee0398e55df7fa7dc4708345ef6e5ac11d23885970d5"
 
 [[files]]
 file = "mods/advanced-mining-dimension.pw.toml"

--- a/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
+++ b/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
@@ -3,8 +3,8 @@
 
 ServerEvents.tags('item', event => {
   // Canonical tags for 1x compressed cobblestone used by mods
-  const TAG_COMPRESSED = (globalThis.CW_TAGS && CW_TAGS.COMPRESSED_COBBLE_1X) || 'forge:compressed/cobblestone_1x'
-  const TAG_STORAGE = (globalThis.CW_TAGS && CW_TAGS.STORAGE_COBBLE) || 'forge:storage_blocks/cobblestone'
+  const TAG_COMPRESSED = (global && global.CW_TAGS && global.CW_TAGS.COMPRESSED_COBBLE_1X) || 'forge:compressed/cobblestone_1x'
+  const TAG_STORAGE = (global && global.CW_TAGS && global.CW_TAGS.STORAGE_COBBLE) || 'forge:storage_blocks/cobblestone'
 
   // Add the ATC 1x compressed cobblestone to both tags
   event.add(TAG_COMPRESSED, 'allthecompressed:cobblestone_1x')

--- a/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
+++ b/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
@@ -1,0 +1,50 @@
+// Ensure Cyclic recipes accept AllTheCompressed compressed cobblestone
+// Covers multiple historical Cyclic item IDs and swaps them to a shared tag.
+
+ServerEvents.tags('item', event => {
+  // Canonical tags for 1x compressed cobblestone used by mods
+  const TAG_COMPRESSED = 'forge:compressed/cobblestone_1x'
+  const TAG_STORAGE = 'forge:storage_blocks/cobblestone'
+
+  // Add the ATC 1x compressed cobblestone to both tags
+  event.add(TAG_COMPRESSED, 'allthecompressed:cobblestone_1x')
+  event.add(TAG_STORAGE, 'allthecompressed:cobblestone_1x')
+
+  // Include likely Cyclic item IDs (safe even if missing)
+  ;[
+    'cyclic:compressed_cobblestone',
+    'cyclic:compressed_cobble',
+    'cyclic:cobblestone_1x',
+  ].forEach(id => {
+    event.add(TAG_COMPRESSED, id)
+    event.add(TAG_STORAGE, id)
+  })
+})
+
+ServerEvents.recipes(event => {
+  const TAG = '#forge:compressed/cobblestone_1x'
+
+  // Replace any recipe input that expects Cyclic's compressed cobblestone variants
+  // with the shared tag that includes AllTheCompressed equivalent.
+  const CYCLIC_IDS = [
+    'cyclic:compressed_cobblestone',
+    'cyclic:compressed_cobble',
+    'cyclic:cobblestone_1x',
+  ]
+
+  CYCLIC_IDS.forEach(id => {
+    // Broadly replace everywhere to catch both Cyclic machine recipes
+    // and any third-party recipes that reference the Cyclic item.
+    event.replaceInput({}, id, TAG)
+  })
+
+  // Be explicit for Cyclic machines just in case
+  ;['cyclic:solidifier', 'cyclic:melter', 'cyclic:crusher', 'cyclic:generator_fluid', 'cyclic:generator_item']
+    .forEach(t => CYCLIC_IDS.forEach(id => event.replaceInput({ type: t }, id, TAG)))
+
+  // Bridging recipe: allow crafting Cyclic compressed cobblestone from ATC 1x
+  // This ensures any hardcoded Cyclic input can be satisfied by converting ATC → Cyclic.
+  event.shapeless('cyclic:compressed_cobblestone', [
+    'allthecompressed:cobblestone_1x'
+  ]).id('cwagecraft:bridge/atc_to_cyclic_compressed_cobble')
+})

--- a/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
+++ b/cwagecraft/kubejs/server_scripts/accept_atc_compressed_cobble.js
@@ -3,19 +3,20 @@
 
 ServerEvents.tags('item', event => {
   // Canonical tags for 1x compressed cobblestone used by mods
-  const TAG_COMPRESSED = 'forge:compressed/cobblestone_1x'
-  const TAG_STORAGE = 'forge:storage_blocks/cobblestone'
+  const TAG_COMPRESSED = (globalThis.CW_TAGS && CW_TAGS.COMPRESSED_COBBLE_1X) || 'forge:compressed/cobblestone_1x'
+  const TAG_STORAGE = (globalThis.CW_TAGS && CW_TAGS.STORAGE_COBBLE) || 'forge:storage_blocks/cobblestone'
 
   // Add the ATC 1x compressed cobblestone to both tags
   event.add(TAG_COMPRESSED, 'allthecompressed:cobblestone_1x')
   event.add(TAG_STORAGE, 'allthecompressed:cobblestone_1x')
 
   // Include likely Cyclic item IDs (safe even if missing)
-  ;[
+  const CYCLIC_IDS = [
     'cyclic:compressed_cobblestone',
     'cyclic:compressed_cobble',
     'cyclic:cobblestone_1x',
-  ].forEach(id => {
+  ]
+  CYCLIC_IDS.forEach(id => {
     event.add(TAG_COMPRESSED, id)
     event.add(TAG_STORAGE, id)
   })
@@ -39,8 +40,8 @@ ServerEvents.recipes(event => {
   })
 
   // Be explicit for Cyclic machines just in case
-  ;['cyclic:solidifier', 'cyclic:melter', 'cyclic:crusher', 'cyclic:generator_fluid', 'cyclic:generator_item']
-    .forEach(t => CYCLIC_IDS.forEach(id => event.replaceInput({ type: t }, id, TAG)))
+  const CYCLIC_TYPES = ['cyclic:solidifier', 'cyclic:melter', 'cyclic:crusher', 'cyclic:generator_fluid', 'cyclic:generator_item']
+  CYCLIC_TYPES.forEach(t => CYCLIC_IDS.forEach(id => event.replaceInput({ type: t }, id, TAG)))
 
   // Bridging recipe: allow crafting Cyclic compressed cobblestone from ATC 1x
   // This ensures any hardcoded Cyclic input can be satisfied by converting ATC → Cyclic.

--- a/cwagecraft/kubejs/startup_scripts/constants.js
+++ b/cwagecraft/kubejs/startup_scripts/constants.js
@@ -1,0 +1,6 @@
+// Shared constants for KubeJS scripts
+globalThis.CW_TAGS = Object.freeze({
+  COMPRESSED_COBBLE_1X: 'forge:compressed/cobblestone_1x',
+  STORAGE_COBBLE: 'forge:storage_blocks/cobblestone',
+})
+

--- a/cwagecraft/kubejs/startup_scripts/constants.js
+++ b/cwagecraft/kubejs/startup_scripts/constants.js
@@ -1,6 +1,5 @@
-// Shared constants for KubeJS scripts
-globalThis.CW_TAGS = Object.freeze({
+// Shared constants for KubeJS scripts (Rhino: use `global`, not `globalThis`)
+global.CW_TAGS = Object.freeze({
   COMPRESSED_COBBLE_1X: 'forge:compressed/cobblestone_1x',
   STORAGE_COBBLE: 'forge:storage_blocks/cobblestone',
 })
-

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "0f7c03e7b0c539cd13bc6f7ae37a9f436e656c5076fb9b5d8540074c8453045d"
+hash = "7263ca4efb71584faac37e42a004b2927f8ca37da5b25843592a5ed590ce2e6e"
 
 [versions]
 forge = "47.3.22"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "ad5f4c674140a56dec38660f8ef47155437e4d2e308d6f0daace3b962de40121"
+hash = "0f7c03e7b0c539cd13bc6f7ae37a9f436e656c5076fb9b5d8540074c8453045d"
 
 [versions]
 forge = "47.3.22"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "ba435b6474c322d8ce563602ef171c2c1cafe71d810d04e85991fb0d1d0eebd7"
+hash = "ad5f4c674140a56dec38660f8ef47155437e4d2e308d6f0daace3b962de40121"
 
 [versions]
 forge = "47.3.22"


### PR DESCRIPTION
Summary
- Cyclic machines (e.g., Solidifier) use forge:storage_blocks/cobblestone; this pack now ensures AllTheCompressed 1x is in that tag so JEI rotates and recipes accept both.
- Adds forge:compressed/cobblestone_1x with both ATC and Cyclic items for consistency.
- KubeJS adds a small bridge (ATC 1x -> cyclic:compressed_cobblestone) to cover any hardcoded references.
- Disables cyclic:compressed_cobblestone_u to avoid conflicts with ATC decompression.
- Documents rebuild vs reload; adds diagnostic scripts + Makefile to gather instance logs/configs and generate a report.

Files of interest
- config/openloader/data/compressed_cobble_tags/... (new tag datapack)
- config/openloader/data/cyclic_recipe_fixes/... (disable compressed_cobblestone_u)
- kubejs/server_scripts/accept_atc_compressed_cobble.js (tag glue + bridge)
- CLAUDE.md (docs)