### PR TITLE
Add vanilla crafting recipe for EnderIO Powered Spawner; fix awk warnings

### DIFF
--- a/cwagecraft/config/openloader/data/cwagecraft_recipe_additions/data/cwagecraft/recipes/powered_spawner.json
+++ b/cwagecraft/config/openloader/data/cwagecraft_recipe_additions/data/cwagecraft/recipes/powered_spawner.json
@@ -1,0 +1,17 @@
+{
+  "type": "minecraft:crafting_shaped",
+  "pattern": [
+    "IBI",
+    "ICI",
+    "VZV"
+  ],
+  "key": {
+    "B": { "item": "enderio:broken_spawner" },
+    "C": { "item": "enderio:ensouled_chassis" },
+    "I": { "tag": "forge:ingots/soularium" },
+    "V": { "tag": "forge:gems/vibrant_crystal" },
+    "Z": { "item": "enderio:z_logic_controller" }
+  },
+  "result": { "item": "enderio:powered_spawner", "count": 1 }
+}
+

--- a/cwagecraft/config/openloader/data/cwagecraft_recipe_additions/pack.mcmeta
+++ b/cwagecraft/config/openloader/data/cwagecraft_recipe_additions/pack.mcmeta
@@ -1,0 +1,7 @@
+{
+  "pack": {
+    "pack_format": 15,
+    "description": "CWagecraft: Add vanilla crafting recipe for EnderIO Powered Spawner (JEI/RS transfer)"
+  }
+}
+

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -165,6 +165,14 @@ file = "config/openloader/data/compressed_cobble_tags/pack.mcmeta"
 hash = "fe8d2276e3eaf60e3b1fb4c413bfb1c8427899e58b28649d9e3db4877eefa7f9"
 
 [[files]]
+file = "config/openloader/data/cwagecraft_recipe_additions/data/cwagecraft/recipes/powered_spawner.json"
+hash = "04c07cc9d8330ddceb53254662c3adcacd643a9853f7146cedbabbe6cb18c849"
+
+[[files]]
+file = "config/openloader/data/cwagecraft_recipe_additions/pack.mcmeta"
+hash = "a3ffe11850add467580c50b8743259667a3e744c20b2dee60f0adfcb8bfefaa5"
+
+[[files]]
 file = "config/openloader/data/cyclic_recipe_fixes/README.md"
 hash = "991b32137ec52531f25da17af6060ca4e48ea40cb4b61f53930efcd1fc51d6ab"
 

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "ce5d800ff70dc77c87d577e6862024bc50cc8495d620b5ff5acaaa6c10019cb7"
+hash = "394a3351be060fa9e80ff20f22a398519a30617035fb4924144ee9fa986fc230"
 
 [versions]
 forge = "47.3.22"

--- a/setup.sh
+++ b/setup.sh
@@ -87,7 +87,7 @@ build_index() {
         /\[update.modrinth\]/{in_mr=1;next}
         /\[update.curseforge\]/{in_cf=1;next}
         /\[/{in_mr=0;in_cf=0}
-        in_mr && /mod-id =/ {gsub(/.*= \"|\"/,"",$0);mr=$0}
+        in_mr && /mod-id =/ {gsub(/.*= "|"/,"",$0);mr=$0}
         in_cf && /project-id =/ {gsub(/.*= /,"",$0);proj=$0}
         END{print mr, proj}
     ' "$f")
@@ -179,7 +179,7 @@ export_mods_yaml() {
         /\[update.modrinth\]/{in_mr=1;next}
         /\[update.curseforge\]/{in_cf=1;next}
         /\[/{in_mr=0;in_cf=0}
-        in_mr && /mod-id =/ {gsub(/.*= \"|\"/,"",$0);mr=$0}
+        in_mr && /mod-id =/ {gsub(/.*= "|"/,"",$0);mr=$0}
         in_cf && /project-id =/ {gsub(/.*= /,"",$0);proj=$0}
         END{print mr, proj}
     ' "$f")


### PR DESCRIPTION
Add vanilla crafting recipe for EnderIO Powered Spawner (JEI/RS transfer); fix awk warnings in setup.sh

Summary
- Adds a standard `minecraft:crafting_shaped` recipe for `enderio:powered_spawner` via an OpenLoader datapack so JEI’s “Crafting” category and RS/vanilla “+” transfer work.
- Keeps EnderIO’s existing `enderio:shaped_entity_storage` recipe intact (for NBT-carrying behavior from `enderio:broken_spawner`).
- Fixes awk regex quoting in `setup.sh` to remove noisy warnings during runs.

Changes
- Add datapack `cwagecraft_recipe_additions`:
  - `cwagecraft/config/openloader/data/cwagecraft_recipe_additions/pack.mcmeta`
  - `cwagecraft/config/openloader/data/cwagecraft_recipe_additions/data/cwagecraft/recipes/powered_spawner.json`
    - Pattern and ingredients mirror EnderIO 6.x:
      - B: `enderio:broken_spawner`
      - C: `enderio:ensouled_chassis`
      - I: `#forge:ingots/soularium`
      - V: `#forge:gems/vibrant_crystal`
      - Z: `enderio:z_logic_controller`
- setup.sh: replace escaped quotes in awk regex with plain quotes to avoid warnings.

Rationale
- EnderIO’s modern recipe uses a custom type so JEI shows a non-vanilla category or Create automation overlay; the vanilla Crafting recipe enables proper JEI/RS transfer.
- We leave the custom recipe in place to preserve entity-NBT handling.

Limitations
- JEI/RS “+” places all inputs except the broken spawner due to NBT ambiguity. This is expected; players can drop any broken spawner into the remaining slot.

Test Plan
- Run `./setup.sh` to refresh the index and export the pack.
- Import and launch the pack.
- In JEI, search “Powered Spawner” → open the Crafting category recipe.
- Click “+” to transfer into crafting table/RS grid; all items should place except the broken spawner.
- Manually insert a broken spawner; craft succeeds.

Issue
- Fixes #72

