### PR TITLE
Alloy Smelter: make EnderIO clear glass from vanilla glass; remove Cyclic smooth-glass overrides

### DIFF
--- a/cwagecraft/config/openloader/data/enderio_recipe_additions/data/enderio/recipes/alloy_smelter/clear_glass_from_vanilla.json
+++ b/cwagecraft/config/openloader/data/enderio_recipe_additions/data/enderio/recipes/alloy_smelter/clear_glass_from_vanilla.json
@@ -1,0 +1,10 @@
+{
+  "type": "enderio:alloy_smelting",
+  "energy": 3200,
+  "experience": 0.3,
+  "inputs": [
+    { "count": 1, "ingredient": { "item": "minecraft:glass" } }
+  ],
+  "result": { "item": "enderio:clear_glass", "count": 1 }
+}
+

--- a/cwagecraft/index.toml
+++ b/cwagecraft/index.toml
@@ -257,6 +257,10 @@ file = "config/openloader/data/enderio_recipe_additions/data/enderio/recipes/all
 hash = "8f4bf25c4f1f677ccfd4b6cbc6a331cedb9085c0cc1144dd1cb8157a93f8969f"
 
 [[files]]
+file = "config/openloader/data/enderio_recipe_additions/data/enderio/recipes/alloy_smelter/clear_glass_from_vanilla.json"
+hash = "d5d96586dc342e1cdbd1c05c0a8b2debe470eba9a5e74842ecf6fde208f8bc87"
+
+[[files]]
 file = "config/openloader/data/enderio_recipe_additions/data/enderio/recipes/alloy_smelter/cobblestone_to_stone.json"
 hash = "b75268e68f06c4a71684fc805a02dde3591f20ac703e21a5fd01a396c4a14ad2"
 
@@ -689,6 +693,10 @@ file = "kubejs/server_scripts/disable_platinum_jetpack.js"
 hash = "9fff6c72c629326f2cbd018de485200d65189e6c4e5e677b33afa94189aac149"
 
 [[files]]
+file = "kubejs/server_scripts/remove_cyclic_smooth_glass.js"
+hash = "f928bbe90c60063c78cdee590741307408e49f7094fe734e2892b1daabc9efa5"
+
+[[files]]
 file = "kubejs/startup_scripts/constants.js"
 hash = "24aa6877fadc790405bbee0398e55df7fa7dc4708345ef6e5ac11d23885970d5"
 
@@ -914,7 +922,7 @@ metafile = true
 
 [[files]]
 file = "mods/enderio.pw.toml"
-hash = "1164df93f3a3b7a8697c69cc51d2bb27c408cb35e5a8b8e0e8255348f6f0bcf5"
+hash = "84e37ac3a18c4262fe5eaef6c49e2d118147ed486b79b9ba9d7a0620bb3d94c5"
 metafile = true
 
 [[files]]

--- a/cwagecraft/kubejs/server_scripts/remove_cyclic_smooth_glass.js
+++ b/cwagecraft/kubejs/server_scripts/remove_cyclic_smooth_glass.js
@@ -1,0 +1,17 @@
+// Remove Cyclic smelting recipes that convert vanilla glass <-> Cyclic smooth/connected glass
+// Rationale: These override EnderIO clear glass visibility/balance in JEI.
+
+ServerEvents.recipes(event => {
+  // Forward: minecraft:glass -> cyclic:glass_connected
+  event.remove({ id: 'cyclic:smelting/glass' });
+
+  // Reverse: cyclic:glass_connected -> minecraft:glass (remove to keep parity)
+  event.remove({ id: 'cyclic:smelting/glass_reverse' });
+
+  // Also remove any EnderIO Alloy Smelter recipes that output Cyclic connected glass
+  // EnderIO may wrap furnace recipes as `enderio:alloy_smelting` in "Alloys & Smelting" mode
+  event.remove({ type: 'enderio:alloy_smelting', output: 'cyclic:glass_connected' });
+
+  // Belt-and-suspenders: remove any remaining recipes producing Cyclic connected glass
+  event.remove({ output: 'cyclic:glass_connected' });
+});

--- a/cwagecraft/mods/enderio.pw.toml
+++ b/cwagecraft/mods/enderio.pw.toml
@@ -1,13 +1,13 @@
 name = "Ender IO"
-filename = "EnderIO-1.20.1-6.2.14-beta-all.jar"
+filename = "EnderIO-1.20.1-6.2.15-beta-all.jar"
 side = "both"
 
 [download]
-url = "https://cdn.modrinth.com/data/49ZofO4f/versions/GL5Uahvn/EnderIO-1.20.1-6.2.14-beta-all.jar"
+url = "https://cdn.modrinth.com/data/49ZofO4f/versions/RstESTNG/EnderIO-1.20.1-6.2.15-beta-all.jar"
 hash-format = "sha512"
-hash = "fcd6a12c7bd6f3709df8440df05abeaa390383f899addfcc5f6ac05858913f374423afb6ba9a4c555ebd2f9175af77a0e6fefcd8d42aa670c91261ca30bd83a7"
+hash = "f480b9b2df6a27306d35730d6147c420123b10a927a4362780c5cd1f51dd24f8c34cad307f0844353d723548d5ff90d65007bd052a814a8897f23351167ed65c"
 
 [update]
 [update.modrinth]
 mod-id = "49ZofO4f"
-version = "GL5Uahvn"
+version = "RstESTNG"

--- a/cwagecraft/pack.toml
+++ b/cwagecraft/pack.toml
@@ -6,7 +6,7 @@ pack-format = "packwiz:1.1.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "394a3351be060fa9e80ff20f22a398519a30617035fb4924144ee9fa986fc230"
+hash = "d830eaae2207ffcad47bf4a7e9ebcd32291593c1e5dc4b1d34df32e0b7930e5f"
 
 [versions]
 forge = "47.3.22"


### PR DESCRIPTION
EnderIO clear glass in Alloy Smelter; remove Cyclic smooth-glass overrides

Summary
- Ensures Alloy Smelter crafts `enderio:clear_glass` from vanilla `minecraft:glass`.
- Removes Cyclic smelting recipe(s) that convert vanilla glass ↔ `cyclic:glass_connected` (smooth/connected glass), which were eclipsing EnderIO clear glass behavior.
- Prevents Alloy Smelter (Alloys & Smelting) from producing Cyclic smooth glass by removing any matching outputs.

Changes
- Add OpenLoader datapack recipe (EnderIO Alloy Smelter):
  - `cwagecraft/config/openloader/data/enderio_recipe_additions/data/enderio/recipes/alloy_smelter/clear_glass_from_vanilla.json`
    - Type: `enderio:alloy_smelting`
    - Input: `minecraft:glass` → Output: `enderio:clear_glass`
    - Energy 3200, XP 0.3
- Add KubeJS server script to remove Cyclic smooth-glass routes:
  - `cwagecraft/kubejs/server_scripts/remove_cyclic_smooth_glass.js`
    - Removes furnace: `cyclic:smelting/glass` and `cyclic:smelting/glass_reverse`
    - Removes Alloy Smelter recipe(s) with output `cyclic:glass_connected`
    - Belt-and-suspenders: removes any recipe outputting `cyclic:glass_connected`

Rationale
- Cyclic’s glass smelting was overriding JEI and machine behavior, resulting in Cyclic smooth glass instead of EnderIO clear glass.
- Success criteria: In Alloy Smelter, inserting vanilla glass yields `enderio:clear_glass`.
- Furnace behavior: It’s acceptable that vanilla furnace no longer converts glass to Cyclic smooth glass.

Test Plan
- Run `./setup.sh`, import the pack, launch.
- In JEI, open Alloy Smelter recipes for `minecraft:glass`; verify a recipe to `enderio:clear_glass` exists.
- Alloy Smelter:
  - Mode: Alloys & Smelting → Insert `minecraft:glass` → Produces `enderio:clear_glass`.
  - Mode: Just Smelting → No conversion (expected, since we removed the furnace recipe). EnderIO’s built-in tag-based recipe may still accept tagged colorless glass.
- Verify there is no remaining path producing `cyclic:glass_connected` in the Alloy Smelter.

Notes
- We did not alter EnderIO’s other clear/fused quartz recolor or progression recipes.
- If desired, we can also add `minecraft:glass` to `forge:glass/colorless` via datapack so the built-in EnderIO recipe covers vanilla glass implicitly; current explicit recipe already ensures success.
